### PR TITLE
Correct batch publishing function name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fn main() {
     }
 
     // Publish a batch of events into the Disruptor.
-    producer.publish_batch(5, |iter| {
+    producer.batch_publish(5, |iter| {
         for e in iter { // `iter` is guaranteed to yield 5 events.
             e.price = 42.0;
         }


### PR DESCRIPTION
Cool library!

I was trying to experiment with it locally, using the examples in the README to get started, but I couldn't get batch publishing to work.

It looks like while the README references `publish_batch`, the actual function for the producer is `batch_publish`.

https://github.com/nicholassm/disruptor-rs/blob/22e13239eddf5f6695238dbde8d6121059dfeb69/src/producer.rs#L218