### PR TITLE
Add dependent sequence gating for consumer relationship graphs and refactor wait strategies

### DIFF
--- a/benches/counters.rs
+++ b/benches/counters.rs
@@ -4,15 +4,15 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use crossbeam::channel::*;
+use disruptor::{build_multi_producer, build_single_producer, BusySpin, Producer};
 use std::hint::black_box;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
-use disruptor::{build_multi_producer, build_single_producer, BusySpin, Producer};
 
-const BUF_SIZE:            usize = 32_768;
+const BUF_SIZE: usize = 32_768;
 const MAX_PRODUCER_EVENTS: usize = 10_000_000;
-const BATCH_SIZE:          usize = 2_000;
+const BATCH_SIZE: usize = 2_000;
 
 fn crossbeam_spsc() {
     let (s, r) = bounded(BUF_SIZE);
@@ -89,16 +89,15 @@ fn crossbeam_mpsc_benchmark(c: &mut Criterion) {
     });
 }
 
-
 struct Event {
-    val: i32
+    val: i32,
 }
 
 fn disruptor_spsc() {
-    let factory = || { Event { val: 0 }}; //to initialize disruptor
+    let factory = || Event { val: 0 }; //to initialize disruptor
 
     let sink = Arc::new(AtomicI32::new(0)); //bcos we read and print value from main thread
-    // Consumer
+                                            // Consumer
     let processor = {
         let sink = Arc::clone(&sink);
         move |event: &Event, _sequence: i64, _end_of_batch: bool| {
@@ -113,7 +112,7 @@ fn disruptor_spsc() {
     // Publish into the Disruptor.
     thread::scope(|s| {
         s.spawn(move || {
-            for _ in 0..MAX_PRODUCER_EVENTS/BATCH_SIZE {
+            for _ in 0..MAX_PRODUCER_EVENTS / BATCH_SIZE {
                 producer.batch_publish(BATCH_SIZE, |iter| {
                     for e in iter {
                         e.val = black_box(1);
@@ -127,10 +126,10 @@ fn disruptor_spsc() {
 }
 
 fn disruptor_mpsc() {
-    let factory = || { Event { val: 0 }}; //to initialize disruptor
+    let factory = || Event { val: 0 }; //to initialize disruptor
 
     let sink = Arc::new(AtomicI32::new(0)); //bcos we read and print value from main thread
-    // Consumer
+                                            // Consumer
     let processor = {
         let sink = Arc::clone(&sink);
         move |event: &Event, _sequence: i64, _end_of_batch: bool| {
@@ -147,7 +146,7 @@ fn disruptor_mpsc() {
     // Publish into the Disruptor.
     thread::scope(|s| {
         s.spawn(move || {
-            for _ in 0..MAX_PRODUCER_EVENTS/BATCH_SIZE {
+            for _ in 0..MAX_PRODUCER_EVENTS / BATCH_SIZE {
                 producer1.batch_publish(BATCH_SIZE, |iter| {
                     for e in iter {
                         e.val = black_box(1);
@@ -157,7 +156,7 @@ fn disruptor_mpsc() {
         });
 
         s.spawn(move || {
-            for _ in 0..MAX_PRODUCER_EVENTS/BATCH_SIZE {
+            for _ in 0..MAX_PRODUCER_EVENTS / BATCH_SIZE {
                 producer2.batch_publish(BATCH_SIZE, |iter| {
                     for e in iter {
                         e.val = 1;
@@ -169,7 +168,6 @@ fn disruptor_mpsc() {
 
     sink.load(Ordering::Acquire);
 }
-
 
 fn disruptor_spsc_benchmark(c: &mut Criterion) {
     c.bench_function("disruptor_spsc", |b| {
@@ -187,5 +185,11 @@ fn disruptor_mpsc_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(counters, crossbeam_spsc_benchmark, disruptor_spsc_benchmark, crossbeam_mpsc_benchmark, disruptor_mpsc_benchmark);
+criterion_group!(
+    counters,
+    crossbeam_spsc_benchmark,
+    disruptor_spsc_benchmark,
+    crossbeam_mpsc_benchmark,
+    disruptor_mpsc_benchmark
+);
 criterion_main!(counters);

--- a/benches/mpsc.rs
+++ b/benches/mpsc.rs
@@ -1,226 +1,266 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering::{Acquire, Release, Relaxed}};
-use std::thread::{self, JoinHandle};
-use std::time::{Duration, Instant};
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput, BenchmarkGroup};
 use criterion::measurement::WallTime;
+use criterion::{
+    black_box, criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
 use crossbeam::channel::TrySendError::Full;
-use crossbeam::channel::{bounded, TryRecvError::{Empty, Disconnected}};
+use crossbeam::channel::{
+    bounded,
+    TryRecvError::{Disconnected, Empty},
+};
 use crossbeam_utils::CachePadded;
 use disruptor::{BusySpin, Producer};
+use std::sync::atomic::{
+    AtomicBool, AtomicI64,
+    Ordering::{Acquire, Relaxed, Release},
+};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
-const PRODUCERS:           usize    = 2;
-const DATA_STRUCTURE_SIZE: usize    = 256;
-const BURST_SIZES:         [u64; 3] = [1, 10, 100];
-const PAUSES_MS:           [u64; 3] = [0,  1,  10];
+const PRODUCERS: usize = 2;
+const DATA_STRUCTURE_SIZE: usize = 256;
+const BURST_SIZES: [u64; 3] = [1, 10, 100];
+const PAUSES_MS: [u64; 3] = [0, 1, 10];
 
 struct Event {
-	data: i64
+    data: i64,
 }
 
 fn pause(millis: u64) {
-	if millis > 0 {
-		thread::sleep(Duration::from_millis(millis));
-	}
+    if millis > 0 {
+        thread::sleep(Duration::from_millis(millis));
+    }
 }
 
 pub fn mpsc_benchmark(c: &mut Criterion) {
-	let mut group = c.benchmark_group("mpsc");
-	for burst_size in BURST_SIZES.into_iter() {
-		group.throughput(Throughput::Elements(burst_size));
+    let mut group = c.benchmark_group("mpsc");
+    for burst_size in BURST_SIZES.into_iter() {
+        group.throughput(Throughput::Elements(burst_size));
 
-		// Base: Benchmark overhead of measurement logic.
-		base(&mut group, burst_size as i64);
+        // Base: Benchmark overhead of measurement logic.
+        base(&mut group, burst_size as i64);
 
-		for pause_ms in PAUSES_MS.into_iter() {
-			let params             = (burst_size as i64, pause_ms);
-			let param_description  = format!("burst: {}, pause: {} ms", burst_size, pause_ms);
+        for pause_ms in PAUSES_MS.into_iter() {
+            let params = (burst_size as i64, pause_ms);
+            let param_description = format!("burst: {}, pause: {} ms", burst_size, pause_ms);
 
-			crossbeam(&mut group, params, &param_description);
-			disruptor(&mut group, params, &param_description);
-		}
-	}
-	group.finish();
+            crossbeam(&mut group, params, &param_description);
+            disruptor(&mut group, params, &param_description);
+        }
+    }
+    group.finish();
 }
 
 /// Structure for managing all producer threads so they can produce a burst again and again in
 /// a benchmark after being released from a barrier. This is to avoid the overhead of creating
 /// new threads for each sample.
 struct BurstProducer {
-	start_barrier: Arc<CachePadded<AtomicBool>>,
-	stop:          Arc<CachePadded<AtomicBool>>,
-	join_handle:   Option<JoinHandle<()>>,
+    start_barrier: Arc<CachePadded<AtomicBool>>,
+    stop: Arc<CachePadded<AtomicBool>>,
+    join_handle: Option<JoinHandle<()>>,
 }
 
 impl BurstProducer {
-	fn new<P>(mut produce_one_burst: P) -> Self
-	where
-		P: 'static + Send + FnMut()
-	{
-		let start_barrier = Arc::new(CachePadded::new(AtomicBool::new(false)));
-		let stop          = Arc::new(CachePadded::new(AtomicBool::new(false)));
+    fn new<P>(mut produce_one_burst: P) -> Self
+    where
+        P: 'static + Send + FnMut(),
+    {
+        let start_barrier = Arc::new(CachePadded::new(AtomicBool::new(false)));
+        let stop = Arc::new(CachePadded::new(AtomicBool::new(false)));
 
-		let join_handle = {
-			let stop          = Arc::clone(&stop);
-			let start_barrier = Arc::clone(&start_barrier);
-			thread::spawn(move || {
-				while !stop.load(Acquire) {
-					// Busy spin with a check if we're done.
-					while start_barrier.compare_exchange(true, false, Acquire, Relaxed).is_err() {
-						if stop.load(Acquire) { return; }
-					}
-					produce_one_burst();
-				}
-			})
-		};
+        let join_handle = {
+            let stop = Arc::clone(&stop);
+            let start_barrier = Arc::clone(&start_barrier);
+            thread::spawn(move || {
+                while !stop.load(Acquire) {
+                    // Busy spin with a check if we're done.
+                    while start_barrier
+                        .compare_exchange(true, false, Acquire, Relaxed)
+                        .is_err()
+                    {
+                        if stop.load(Acquire) {
+                            return;
+                        }
+                    }
+                    produce_one_burst();
+                }
+            })
+        };
 
-		Self {
-			start_barrier,
-			stop,
-			join_handle: Some(join_handle)
-		}
-	}
+        Self {
+            start_barrier,
+            stop,
+            join_handle: Some(join_handle),
+        }
+    }
 
-	fn start(&self) {
-		self.start_barrier.store(true, Release);
-	}
+    fn start(&self) {
+        self.start_barrier.store(true, Release);
+    }
 
-	fn stop(&mut self) {
-		self.stop.store(true, Release);
-		self.join_handle.take().unwrap().join().expect("Should not panic.");
-	}
+    fn stop(&mut self) {
+        self.stop.store(true, Release);
+        self.join_handle
+            .take()
+            .unwrap()
+            .join()
+            .expect("Should not panic.");
+    }
 }
 
 fn run_benchmark(
-	group:           &mut BenchmarkGroup<WallTime>,
-	benchmark_id:    BenchmarkId,
-	burst_size:      Arc<AtomicI64>,
-	sink:            Arc<AtomicI64>,
-	params:          (i64, u64),
-	burst_producers: &[BurstProducer])
-{
-	group.bench_with_input(benchmark_id, &params, move |b, (size, pause_ms)| b.iter_custom(|iters| {
-		burst_size.store(*size, Release);
-		let count = black_box(*size * burst_producers.len() as i64);
-		pause(*pause_ms);
-		let start = Instant::now();
-		for _ in 0..iters {
-			sink.store(0, Release);
-			burst_producers.iter().for_each(BurstProducer::start);
-			// Wait for all producers to finish publication.
-			while sink.load(Acquire) != count {/* Busy spin. */}
-		}
-		start.elapsed()
-	}));
+    group: &mut BenchmarkGroup<WallTime>,
+    benchmark_id: BenchmarkId,
+    burst_size: Arc<AtomicI64>,
+    sink: Arc<AtomicI64>,
+    params: (i64, u64),
+    burst_producers: &[BurstProducer],
+) {
+    group.bench_with_input(benchmark_id, &params, move |b, (size, pause_ms)| {
+        b.iter_custom(|iters| {
+            burst_size.store(*size, Release);
+            let count = black_box(*size * burst_producers.len() as i64);
+            pause(*pause_ms);
+            let start = Instant::now();
+            for _ in 0..iters {
+                sink.store(0, Release);
+                burst_producers.iter().for_each(BurstProducer::start);
+                // Wait for all producers to finish publication.
+                while sink.load(Acquire) != count { /* Busy spin. */ }
+            }
+            start.elapsed()
+        })
+    });
 }
 
 fn base(group: &mut BenchmarkGroup<WallTime>, size: i64) {
-	let sink                = Arc::new(AtomicI64::new(0));
-	let benchmark_id        = BenchmarkId::new("base", size);
-	let burst_size          = Arc::new(AtomicI64::new(0));
-	let mut burst_producers = (0..PRODUCERS)
-		.into_iter()
-		.map(|_| {
-			let sink       = Arc::clone(&sink);
-			let burst_size = Arc::clone(&burst_size);
-			BurstProducer::new(move || {
-				let burst_size = burst_size.load(Acquire);
-				for _ in 0..burst_size {
-					sink.fetch_add(1, Release);
-				}
-			})
-		})
-		.collect::<Vec<BurstProducer>>();
+    let sink = Arc::new(AtomicI64::new(0));
+    let benchmark_id = BenchmarkId::new("base", size);
+    let burst_size = Arc::new(AtomicI64::new(0));
+    let mut burst_producers = (0..PRODUCERS)
+        .into_iter()
+        .map(|_| {
+            let sink = Arc::clone(&sink);
+            let burst_size = Arc::clone(&burst_size);
+            BurstProducer::new(move || {
+                let burst_size = burst_size.load(Acquire);
+                for _ in 0..burst_size {
+                    sink.fetch_add(1, Release);
+                }
+            })
+        })
+        .collect::<Vec<BurstProducer>>();
 
-	run_benchmark(group, benchmark_id, burst_size, sink, (size, 0), &burst_producers);
-	burst_producers.iter_mut().for_each(BurstProducer::stop);
+    run_benchmark(
+        group,
+        benchmark_id,
+        burst_size,
+        sink,
+        (size, 0),
+        &burst_producers,
+    );
+    burst_producers.iter_mut().for_each(BurstProducer::stop);
 }
 
 fn crossbeam(group: &mut BenchmarkGroup<WallTime>, params: (i64, u64), param_description: &str) {
-	// Use an AtomicI64 to count the number of events from the receiving thread.
-	let sink     = Arc::new(AtomicI64::new(0));
-	let (s, r)   = bounded::<Event>(DATA_STRUCTURE_SIZE);
-	let receiver = {
-		let sink = Arc::clone(&sink);
-		thread::spawn(move || {
-			loop {
-				match r.try_recv() {
-					Ok(event)         => {
-						black_box(event.data);
-						sink.fetch_add(1, Release);
-					},
-					Err(Empty)        => continue,
-					Err(Disconnected) => break,
-				}
-			}
-		})
-	};
-	let benchmark_id        = BenchmarkId::new("Crossbeam", &param_description);
-	let burst_size          = Arc::new(AtomicI64::new(0));
-	let mut burst_producers = (0..PRODUCERS)
-		.into_iter()
-		.map(|_| {
-			let burst_size = Arc::clone(&burst_size);
-			let s          = s.clone();
-			BurstProducer::new(move || {
-				let burst_size = burst_size.load(Acquire);
-				for data in 0..burst_size {
-					let mut event = Event { data: black_box(data) };
-					loop {
-						match s.try_send(event) {
-							Err(Full(e)) => event = e,
-							_            => break,
-						}
-					}
-				}
-			})
-		})
-		.collect::<Vec<BurstProducer>>();
-	drop(s); // Original send channel not used.
+    // Use an AtomicI64 to count the number of events from the receiving thread.
+    let sink = Arc::new(AtomicI64::new(0));
+    let (s, r) = bounded::<Event>(DATA_STRUCTURE_SIZE);
+    let receiver = {
+        let sink = Arc::clone(&sink);
+        thread::spawn(move || loop {
+            match r.try_recv() {
+                Ok(event) => {
+                    black_box(event.data);
+                    sink.fetch_add(1, Release);
+                }
+                Err(Empty) => continue,
+                Err(Disconnected) => break,
+            }
+        })
+    };
+    let benchmark_id = BenchmarkId::new("Crossbeam", &param_description);
+    let burst_size = Arc::new(AtomicI64::new(0));
+    let mut burst_producers = (0..PRODUCERS)
+        .into_iter()
+        .map(|_| {
+            let burst_size = Arc::clone(&burst_size);
+            let s = s.clone();
+            BurstProducer::new(move || {
+                let burst_size = burst_size.load(Acquire);
+                for data in 0..burst_size {
+                    let mut event = Event {
+                        data: black_box(data),
+                    };
+                    loop {
+                        match s.try_send(event) {
+                            Err(Full(e)) => event = e,
+                            _ => break,
+                        }
+                    }
+                }
+            })
+        })
+        .collect::<Vec<BurstProducer>>();
+    drop(s); // Original send channel not used.
 
-	run_benchmark(group, benchmark_id, burst_size, sink, params, &burst_producers);
+    run_benchmark(
+        group,
+        benchmark_id,
+        burst_size,
+        sink,
+        params,
+        &burst_producers,
+    );
 
-	burst_producers.iter_mut().for_each(BurstProducer::stop);
-	receiver.join().expect("Should not have panicked.");
+    burst_producers.iter_mut().for_each(BurstProducer::stop);
+    receiver.join().expect("Should not have panicked.");
 }
 
 fn disruptor(group: &mut BenchmarkGroup<WallTime>, params: (i64, u64), param_description: &str) {
-	let factory   = || { Event { data: 0 } };
-	// Use an AtomicI64 to count number of received events.
-	let sink      = Arc::new(AtomicI64::new(0));
-	let processor = {
-		let sink = Arc::clone(&sink);
-		move |event: &Event, _sequence: i64, _end_of_batch: bool| {
-			// Black box event to avoid dead code elimination.
-			black_box(event.data);
-			sink.fetch_add(1, Release);
-		}
-	};
-	let producer = disruptor::build_multi_producer(DATA_STRUCTURE_SIZE, factory, BusySpin)
-		.handle_events_with(processor)
-		.build();
-	let benchmark_id        = BenchmarkId::new("disruptor", &param_description);
-	let burst_size          = Arc::new(AtomicI64::new(0));
-	let mut burst_producers = (0..PRODUCERS)
-		.into_iter()
-		.map(|_| {
-			let burst_size   = Arc::clone(&burst_size);
-			let mut producer = producer.clone();
-			BurstProducer::new(move || {
-				let burst_size = burst_size.load(Acquire);
-				producer.batch_publish(burst_size as usize, |iter| {
-					for (i, e) in iter.enumerate() {
-						e.data = black_box(i as i64);
-					}
-				});
-			})
-		})
-		.collect::<Vec<BurstProducer>>();
-	drop(producer); // Original producer not used.
+    let factory = || Event { data: 0 };
+    // Use an AtomicI64 to count number of received events.
+    let sink = Arc::new(AtomicI64::new(0));
+    let processor = {
+        let sink = Arc::clone(&sink);
+        move |event: &Event, _sequence: i64, _end_of_batch: bool| {
+            // Black box event to avoid dead code elimination.
+            black_box(event.data);
+            sink.fetch_add(1, Release);
+        }
+    };
+    let producer = disruptor::build_multi_producer(DATA_STRUCTURE_SIZE, factory, BusySpin)
+        .handle_events_with(processor)
+        .build();
+    let benchmark_id = BenchmarkId::new("disruptor", &param_description);
+    let burst_size = Arc::new(AtomicI64::new(0));
+    let mut burst_producers = (0..PRODUCERS)
+        .into_iter()
+        .map(|_| {
+            let burst_size = Arc::clone(&burst_size);
+            let mut producer = producer.clone();
+            BurstProducer::new(move || {
+                let burst_size = burst_size.load(Acquire);
+                producer.batch_publish(burst_size as usize, |iter| {
+                    for (i, e) in iter.enumerate() {
+                        e.data = black_box(i as i64);
+                    }
+                });
+            })
+        })
+        .collect::<Vec<BurstProducer>>();
+    drop(producer); // Original producer not used.
 
-	run_benchmark(group, benchmark_id, burst_size, sink, params, &burst_producers);
+    run_benchmark(
+        group,
+        benchmark_id,
+        burst_size,
+        sink,
+        params,
+        &burst_producers,
+    );
 
-	burst_producers.iter_mut().for_each(BurstProducer::stop);
+    burst_producers.iter_mut().for_each(BurstProducer::stop);
 }
 
 criterion_group!(mpsc, mpsc_benchmark);

--- a/benches/poller.rs
+++ b/benches/poller.rs
@@ -1,139 +1,144 @@
-use std::sync::Arc;
+use criterion::measurement::WallTime;
+use criterion::{
+    black_box, criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
+use disruptor::{BusySpin, Producer};
 use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
 use std::thread::{self, spawn};
 use std::time::{Duration, Instant};
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput, BenchmarkGroup};
-use criterion::measurement::WallTime;
-use disruptor::{BusySpin, Producer};
 
 const DATA_STRUCTURE_SIZE: usize = 128;
-const BURST_SIZES: [u64; 3]      = [1, 10, 100];
-const PAUSES_MS: [u64; 3]        = [0,  1,  10];
+const BURST_SIZES: [u64; 3] = [1, 10, 100];
+const PAUSES_MS: [u64; 3] = [0, 1, 10];
 
 struct Event {
-	data: i64
+    data: i64,
 }
 
 fn pause(millis: u64) {
-	if millis > 0 {
-		thread::sleep(Duration::from_millis(millis));
-	}
+    if millis > 0 {
+        thread::sleep(Duration::from_millis(millis));
+    }
 }
 
 pub fn poller_benchmark(c: &mut Criterion) {
-	let mut group = c.benchmark_group("spsc");
-	for burst_size in BURST_SIZES.into_iter() {
-		group.throughput(Throughput::Elements(burst_size));
+    let mut group = c.benchmark_group("spsc");
+    for burst_size in BURST_SIZES.into_iter() {
+        group.throughput(Throughput::Elements(burst_size));
 
-		// Base: Benchmark overhead of measurement logic.
-		base(&mut group, burst_size as i64);
+        // Base: Benchmark overhead of measurement logic.
+        base(&mut group, burst_size as i64);
 
-		for pause_ms in PAUSES_MS.into_iter() {
-			let inputs = (burst_size as i64, pause_ms);
-			let param  = format!("burst: {}, pause: {} ms", burst_size, pause_ms);
+        for pause_ms in PAUSES_MS.into_iter() {
+            let inputs = (burst_size as i64, pause_ms);
+            let param = format!("burst: {}, pause: {} ms", burst_size, pause_ms);
 
-			polling(&mut group, inputs, &param);
-			processing(&mut group, inputs, &param);
-		}
-	}
-	group.finish();
+            polling(&mut group, inputs, &param);
+            processing(&mut group, inputs, &param);
+        }
+    }
+    group.finish();
 }
 
 // Synthetic benchmark to measure the overhead of the measurement itself.
 fn base(group: &mut BenchmarkGroup<WallTime>, burst_size: i64) {
-	let sink         = Arc::new(AtomicI64::new(0));
-	let benchmark_id = BenchmarkId::new("base", burst_size);
-	group.bench_with_input(benchmark_id, &burst_size, move |b, size| b.iter_custom(|iters| {
-		let start = Instant::now();
-		for _ in 0..iters {
-			for data in 1..=*size {
-				sink.store(black_box(data), Ordering::Release);
-			}
-			// Wait for the last data element to "be received".
-			let last_data = black_box(*size);
-			while sink.load(Ordering::Acquire) != last_data {}
-		}
-		start.elapsed()
-	}));
+    let sink = Arc::new(AtomicI64::new(0));
+    let benchmark_id = BenchmarkId::new("base", burst_size);
+    group.bench_with_input(benchmark_id, &burst_size, move |b, size| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _ in 0..iters {
+                for data in 1..=*size {
+                    sink.store(black_box(data), Ordering::Release);
+                }
+                // Wait for the last data element to "be received".
+                let last_data = black_box(*size);
+                while sink.load(Ordering::Acquire) != last_data {}
+            }
+            start.elapsed()
+        })
+    });
 }
 
 fn polling(group: &mut BenchmarkGroup<WallTime>, inputs: (i64, u64), param: &str) {
-	let factory = || { Event { data: 0 } };
+    let factory = || Event { data: 0 };
 
-	let builder = disruptor::build_single_producer(DATA_STRUCTURE_SIZE, factory, BusySpin);
-	let (mut poller, builder) = builder.event_poller();
-	let mut producer = builder.build();
+    let builder = disruptor::build_single_producer(DATA_STRUCTURE_SIZE, factory, BusySpin);
+    let (mut poller, builder) = builder.event_poller();
+    let mut producer = builder.build();
 
-	// Use an AtomicI64 to "extract" the value from the processing thread with the Event Poller.
-	let sink = Arc::new(AtomicI64::new(0));
-	let join_handle = {
-		let sink = Arc::clone(&sink);
-		spawn(move || {
-			loop {
-				match poller.poll() {
-					Ok(mut events) => {
-						for event in &mut events {
-							sink.store(event.data, Ordering::Release);
-						}
-					},
-					Err(disruptor::Polling::NoEvents) => continue,
-					Err(disruptor::Polling::Shutdown) => break,
-				}
-			}
-		})
-	};
+    // Use an AtomicI64 to "extract" the value from the processing thread with the Event Poller.
+    let sink = Arc::new(AtomicI64::new(0));
+    let join_handle = {
+        let sink = Arc::clone(&sink);
+        spawn(move || loop {
+            match poller.poll() {
+                Ok(mut events) => {
+                    for event in &mut events {
+                        sink.store(event.data, Ordering::Release);
+                    }
+                }
+                Err(disruptor::Polling::NoEvents) => continue,
+                Err(disruptor::Polling::Shutdown) => break,
+            }
+        })
+    };
 
-	let benchmark_id = BenchmarkId::new("polling", &param);
-	group.bench_with_input(benchmark_id, &inputs, move |b, (size, pause_ms) | b.iter_custom(|iters| {
-		pause(*pause_ms);
-		let start = Instant::now();
-		for _ in 0..iters {
-			producer.batch_publish(*size as usize, |iter| {
-				for (i, e) in iter.enumerate() {
-					e.data = black_box(i as i64 + 1);
-				}
-			});
+    let benchmark_id = BenchmarkId::new("polling", &param);
+    group.bench_with_input(benchmark_id, &inputs, move |b, (size, pause_ms)| {
+        b.iter_custom(|iters| {
+            pause(*pause_ms);
+            let start = Instant::now();
+            for _ in 0..iters {
+                producer.batch_publish(*size as usize, |iter| {
+                    for (i, e) in iter.enumerate() {
+                        e.data = black_box(i as i64 + 1);
+                    }
+                });
 
-			// Wait for the last data element to be received inside processor.
-			let last_data = black_box(*size);
-			while sink.load(Ordering::Acquire) != last_data {}
+                // Wait for the last data element to be received inside processor.
+                let last_data = black_box(*size);
+                while sink.load(Ordering::Acquire) != last_data {}
+            }
+            start.elapsed()
+        })
+    });
 
-		}
-		start.elapsed()
-	}));
-
-	join_handle.join().expect("Polling thread panicked");
+    join_handle.join().expect("Polling thread panicked");
 }
 
 fn processing(group: &mut BenchmarkGroup<WallTime>, inputs: (i64, u64), param: &str) {
-	let factory = || { Event { data: 0 } };
-	// Use an AtomicI64 to "extract" the value from the processing thread.
-	let sink      = Arc::new(AtomicI64::new(0));
-	let processor = {
-		let sink = Arc::clone(&sink);
-		move |event: &Event, _sequence: i64, _end_of_batch: bool| {
-			sink.store(event.data, Ordering::Release);
-		}
-	};
-	let mut producer = disruptor::build_single_producer(DATA_STRUCTURE_SIZE, factory, BusySpin)
-		.handle_events_with(processor)
-		.build();
-	let benchmark_id = BenchmarkId::new("processing", &param);
-	group.bench_with_input(benchmark_id, &inputs, move |b, (size, pause_ms) | b.iter_custom(|iters| {
-		pause(*pause_ms);
-		let start = Instant::now();
-		for _ in 0..iters {
-			producer.batch_publish(*size as usize, |iter| {
-				for (i, e) in iter.enumerate() {
-					e.data = black_box(i as i64 + 1);
-				}
-			});
-			// Wait for the last data element to be received inside processor.
-			let last_data = black_box(*size);
-			while sink.load(Ordering::Acquire) != last_data {}
-		}
-		start.elapsed()
-	}));
+    let factory = || Event { data: 0 };
+    // Use an AtomicI64 to "extract" the value from the processing thread.
+    let sink = Arc::new(AtomicI64::new(0));
+    let processor = {
+        let sink = Arc::clone(&sink);
+        move |event: &Event, _sequence: i64, _end_of_batch: bool| {
+            sink.store(event.data, Ordering::Release);
+        }
+    };
+    let mut producer = disruptor::build_single_producer(DATA_STRUCTURE_SIZE, factory, BusySpin)
+        .handle_events_with(processor)
+        .build();
+    let benchmark_id = BenchmarkId::new("processing", &param);
+    group.bench_with_input(benchmark_id, &inputs, move |b, (size, pause_ms)| {
+        b.iter_custom(|iters| {
+            pause(*pause_ms);
+            let start = Instant::now();
+            for _ in 0..iters {
+                producer.batch_publish(*size as usize, |iter| {
+                    for (i, e) in iter.enumerate() {
+                        e.data = black_box(i as i64 + 1);
+                    }
+                });
+                // Wait for the last data element to be received inside processor.
+                let last_data = black_box(*size);
+                while sink.load(Ordering::Acquire) != last_data {}
+            }
+            start.elapsed()
+        })
+    });
 }
 
 criterion_group!(poller, poller_benchmark);

--- a/benches/spsc.rs
+++ b/benches/spsc.rs
@@ -1,132 +1,143 @@
-use std::sync::Arc;
+use criterion::measurement::WallTime;
+use criterion::{
+    black_box, criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
+use crossbeam::channel::TrySendError::Full;
+use crossbeam::channel::{
+    bounded,
+    TryRecvError::{Disconnected, Empty},
+};
+use disruptor::{BusySpin, Producer};
 use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput, BenchmarkGroup};
-use criterion::measurement::WallTime;
-use crossbeam::channel::TrySendError::Full;
-use crossbeam::channel::{bounded, TryRecvError::{Empty, Disconnected}};
-use disruptor::{BusySpin, Producer};
 
 const DATA_STRUCTURE_SIZE: usize = 128;
-const BURST_SIZES: [u64; 3]      = [1, 10, 100];
-const PAUSES_MS: [u64; 3]        = [0,  1,  10];
+const BURST_SIZES: [u64; 3] = [1, 10, 100];
+const PAUSES_MS: [u64; 3] = [0, 1, 10];
 
 struct Event {
-	data: i64
+    data: i64,
 }
 
 fn pause(millis: u64) {
-	if millis > 0 {
-		thread::sleep(Duration::from_millis(millis));
-	}
+    if millis > 0 {
+        thread::sleep(Duration::from_millis(millis));
+    }
 }
 
 pub fn spsc_benchmark(c: &mut Criterion) {
-	let mut group = c.benchmark_group("spsc");
-	for burst_size in BURST_SIZES.into_iter() {
-		group.throughput(Throughput::Elements(burst_size));
+    let mut group = c.benchmark_group("spsc");
+    for burst_size in BURST_SIZES.into_iter() {
+        group.throughput(Throughput::Elements(burst_size));
 
-		// Base: Benchmark overhead of measurement logic.
-		base(&mut group, burst_size as i64);
+        // Base: Benchmark overhead of measurement logic.
+        base(&mut group, burst_size as i64);
 
-		for pause_ms in PAUSES_MS.into_iter() {
-			let inputs = (burst_size as i64, pause_ms);
-			let param  = format!("burst: {}, pause: {} ms", burst_size, pause_ms);
+        for pause_ms in PAUSES_MS.into_iter() {
+            let inputs = (burst_size as i64, pause_ms);
+            let param = format!("burst: {}, pause: {} ms", burst_size, pause_ms);
 
-			crossbeam(&mut group, inputs, &param);
-			disruptor(&mut group, inputs, &param);
-		}
-	}
-	group.finish();
+            crossbeam(&mut group, inputs, &param);
+            disruptor(&mut group, inputs, &param);
+        }
+    }
+    group.finish();
 }
 
 // Synthetic benchmark to measure the overhead of the measurement itself.
 fn base(group: &mut BenchmarkGroup<WallTime>, burst_size: i64) {
-	let sink         = Arc::new(AtomicI64::new(0));
-	let benchmark_id = BenchmarkId::new("base", burst_size);
-	group.bench_with_input(benchmark_id, &burst_size, move |b, size| b.iter_custom(|iters| {
-		let start = Instant::now();
-		for _ in 0..iters {
-			for data in 1..=*size {
-				sink.store(black_box(data), Ordering::Release);
-			}
-			// Wait for the last data element to "be received".
-			let last_data = black_box(*size);
-			while sink.load(Ordering::Acquire) != last_data {}
-		}
-		start.elapsed()
-	}));
+    let sink = Arc::new(AtomicI64::new(0));
+    let benchmark_id = BenchmarkId::new("base", burst_size);
+    group.bench_with_input(benchmark_id, &burst_size, move |b, size| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _ in 0..iters {
+                for data in 1..=*size {
+                    sink.store(black_box(data), Ordering::Release);
+                }
+                // Wait for the last data element to "be received".
+                let last_data = black_box(*size);
+                while sink.load(Ordering::Acquire) != last_data {}
+            }
+            start.elapsed()
+        })
+    });
 }
 
 fn crossbeam(group: &mut BenchmarkGroup<WallTime>, inputs: (i64, u64), param: &str) {
-	// Use an AtomicI64 to "extract" the value from the receiving thread.
-	let sink     = Arc::new(AtomicI64::new(0));
-	let (s, r)   = bounded::<Event>(DATA_STRUCTURE_SIZE);
-	let receiver = {
-		let sink = Arc::clone(&sink);
-		thread::spawn(move || {
-			loop {
-				match r.try_recv() {
-					Ok(event)         => sink.store(event.data, Ordering::Release),
-					Err(Empty)        => continue,
-					Err(Disconnected) => break,
-				}
-			}
-		})
-	};
-	let benchmark_id = BenchmarkId::new("Crossbeam", &param);
-	group.bench_with_input(benchmark_id, &inputs, move |b, (size, pause_ms)| b.iter_custom(|iters| {
-		pause(*pause_ms);
-		let start = Instant::now();
-		for _ in 0..iters {
-			for data in 1..=*size {
-				let mut event = Event { data: black_box(data) };
-				loop {
-					match s.try_send(event) {
-						Err(Full(e)) => event = e,
-						_            => break,
-					}
-				}
-			}
-			// Wait for the last data element to be received in the receiver thread.
-			let last_data = black_box(*size);
-			while sink.load(Ordering::Acquire) != last_data {}
-		}
-		start.elapsed()
-	}));
-	receiver.join().expect("Should not have panicked.");
+    // Use an AtomicI64 to "extract" the value from the receiving thread.
+    let sink = Arc::new(AtomicI64::new(0));
+    let (s, r) = bounded::<Event>(DATA_STRUCTURE_SIZE);
+    let receiver = {
+        let sink = Arc::clone(&sink);
+        thread::spawn(move || loop {
+            match r.try_recv() {
+                Ok(event) => sink.store(event.data, Ordering::Release),
+                Err(Empty) => continue,
+                Err(Disconnected) => break,
+            }
+        })
+    };
+    let benchmark_id = BenchmarkId::new("Crossbeam", &param);
+    group.bench_with_input(benchmark_id, &inputs, move |b, (size, pause_ms)| {
+        b.iter_custom(|iters| {
+            pause(*pause_ms);
+            let start = Instant::now();
+            for _ in 0..iters {
+                for data in 1..=*size {
+                    let mut event = Event {
+                        data: black_box(data),
+                    };
+                    loop {
+                        match s.try_send(event) {
+                            Err(Full(e)) => event = e,
+                            _ => break,
+                        }
+                    }
+                }
+                // Wait for the last data element to be received in the receiver thread.
+                let last_data = black_box(*size);
+                while sink.load(Ordering::Acquire) != last_data {}
+            }
+            start.elapsed()
+        })
+    });
+    receiver.join().expect("Should not have panicked.");
 }
 
 fn disruptor(group: &mut BenchmarkGroup<WallTime>, inputs: (i64, u64), param: &str) {
-	let factory = || { Event { data: 0 } };
-	// Use an AtomicI64 to "extract" the value from the processing thread.
-	let sink      = Arc::new(AtomicI64::new(0));
-	let processor = {
-		let sink = Arc::clone(&sink);
-		move |event: &Event, _sequence: i64, _end_of_batch: bool| {
-			sink.store(event.data, Ordering::Release);
-		}
-	};
-	let mut producer = disruptor::build_single_producer(DATA_STRUCTURE_SIZE, factory, BusySpin)
-		.handle_events_with(processor)
-		.build();
-	let benchmark_id = BenchmarkId::new("disruptor", &param);
-	group.bench_with_input(benchmark_id, &inputs, move |b, (size, pause_ms) | b.iter_custom(|iters| {
-		pause(*pause_ms);
-		let start = Instant::now();
-		for _ in 0..iters {
-			producer.batch_publish(*size as usize, |iter| {
-				for (i, e) in iter.enumerate() {
-					e.data = black_box(i as i64 + 1);
-				}
-			});
-			// Wait for the last data element to be received inside processor.
-			let last_data = black_box(*size);
-			while sink.load(Ordering::Acquire) != last_data {}
-		}
-		start.elapsed()
-	}));
+    let factory = || Event { data: 0 };
+    // Use an AtomicI64 to "extract" the value from the processing thread.
+    let sink = Arc::new(AtomicI64::new(0));
+    let processor = {
+        let sink = Arc::clone(&sink);
+        move |event: &Event, _sequence: i64, _end_of_batch: bool| {
+            sink.store(event.data, Ordering::Release);
+        }
+    };
+    let mut producer = disruptor::build_single_producer(DATA_STRUCTURE_SIZE, factory, BusySpin)
+        .handle_events_with(processor)
+        .build();
+    let benchmark_id = BenchmarkId::new("disruptor", &param);
+    group.bench_with_input(benchmark_id, &inputs, move |b, (size, pause_ms)| {
+        b.iter_custom(|iters| {
+            pause(*pause_ms);
+            let start = Instant::now();
+            for _ in 0..iters {
+                producer.batch_publish(*size as usize, |iter| {
+                    for (i, e) in iter.enumerate() {
+                        e.data = black_box(i as i64 + 1);
+                    }
+                });
+                // Wait for the last data element to be received inside processor.
+                let last_data = black_box(*size);
+                while sink.load(Ordering::Acquire) != last_data {}
+            }
+            start.elapsed()
+        })
+    });
 }
 
 criterion_group!(spsc, spsc_benchmark);

--- a/src/affinity.rs
+++ b/src/affinity.rs
@@ -1,20 +1,25 @@
 use core_affinity::CoreId;
 
 pub(crate) fn cpu_has_core_else_panic(id: usize) {
-	let available: Vec<usize> = core_affinity::get_core_ids().unwrap().iter()
-		.map(|core_id| core_id.id)
-		.collect();
+    let available: Vec<usize> = core_affinity::get_core_ids()
+        .unwrap()
+        .iter()
+        .map(|core_id| core_id.id)
+        .collect();
 
-	if !available.contains(&id) {
-		panic!("No core with ID={} is available.", id);
-	}
+    if !available.contains(&id) {
+        panic!("No core with ID={} is available.", id);
+    }
 }
 
 pub(crate) fn set_affinity_if_defined(core_affinity: Option<CoreId>, thread_name: &str) {
-	if let Some(core_id) = core_affinity {
-		let got_pinned = core_affinity::set_for_current(core_id);
-		if !got_pinned {
-			eprintln!("Could not pin processor thread '{}' to {:?}.", thread_name, core_id);
-		}
-	}
+    if let Some(core_id) = core_affinity {
+        let got_pinned = core_affinity::set_for_current(core_id);
+        if !got_pinned {
+            eprintln!(
+                "Could not pin processor thread '{}' to {:?}.",
+                thread_name, core_id
+            );
+        }
+    }
 }

--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -5,10 +5,10 @@ pub const NONE: Sequence = -1;
 
 #[doc(hidden)]
 pub trait Barrier: Send + Sync {
-	/// Gets the sequence number of the barrier with relaxed memory ordering.
-	/// `prev` must be the last sequence returned from this barrier.
-	///
-	/// Note, to establish proper happens-before relationships (and thus proper synchronization),
-	/// the caller must issue a [`std::sync::atomic::fence`] with [`Ordering::Acquire`].
-	fn get_after(&self, prev: Sequence) -> Sequence;
+    /// Gets the sequence number of the barrier with relaxed memory ordering.
+    /// `prev` must be the last sequence returned from this barrier.
+    ///
+    /// Note, to establish proper happens-before relationships (and thus proper synchronization),
+    /// the caller must issue a [`std::sync::atomic::fence`] with [`Ordering::Acquire`].
+    fn get_after(&self, prev: Sequence) -> Sequence;
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,20 +2,25 @@
 //!
 //! Use [build_single_producer] or [build_multi_producer] to get started.
 
-use std::sync::{atomic::AtomicI64, Arc};
-use core_affinity::CoreId;
-use crossbeam_utils::CachePadded;
-use crate::{affinity::cpu_has_core_else_panic, barrier::{Barrier, NONE}, consumer::{start_processor, start_processor_with_state, event_poller::EventPoller}, Sequence};
 use crate::consumer::Consumer;
 use crate::cursor::Cursor;
-use crate::producer::{single::SingleProducerBarrier, multi::MultiProducerBarrier};
+use crate::producer::{multi::MultiProducerBarrier, single::SingleProducerBarrier};
 use crate::ringbuffer::RingBuffer;
 use crate::wait_strategies::WaitStrategy;
+use crate::{
+    affinity::cpu_has_core_else_panic,
+    barrier::{Barrier, NONE},
+    consumer::{event_poller::EventPoller, start_processor, start_processor_with_state},
+    Sequence,
+};
+use core_affinity::CoreId;
+use crossbeam_utils::CachePadded;
+use std::sync::{atomic::AtomicI64, Arc};
 
 use self::{multi::MPBuilder, single::SPBuilder};
 
-pub mod single;
 pub mod multi;
+pub mod single;
 
 /// State: No consumers (yet).
 pub struct NC;
@@ -51,16 +56,25 @@ pub struct MC;
 ///
 /// // Now use the `producer` to publish events.
 /// ```
-pub fn build_single_producer<E, W, F>(size: usize, event_factory: F, wait_strategy: W)
--> SPBuilder<NC, E, W, SingleProducerBarrier>
+pub fn build_single_producer<E, W, F>(
+    size: usize,
+    event_factory: F,
+    wait_strategy: W,
+) -> SPBuilder<NC, E, W, SingleProducerBarrier>
 where
-	F: FnMut() -> E,
-	E: 'static + Send + Sync,
-	W: 'static + WaitStrategy,
+    F: FnMut() -> E,
+    E: 'static + Send + Sync,
+    W: 'static + WaitStrategy,
 {
-	let producer_barrier  = Arc::new(SingleProducerBarrier::new());
-	let dependent_barrier = Arc::clone(&producer_barrier);
-	SPBuilder::new(size, event_factory, wait_strategy, producer_barrier, dependent_barrier)
+    let producer_barrier = Arc::new(SingleProducerBarrier::new());
+    let dependent_barrier = Arc::clone(&producer_barrier);
+    SPBuilder::new(
+        size,
+        event_factory,
+        wait_strategy,
+        producer_barrier,
+        dependent_barrier,
+    )
 }
 
 /// Build a multi producer Disruptor. Use this if you need to publish events from many threads.
@@ -92,16 +106,25 @@ where
 ///
 /// // Now two threads can get a Producer each.
 /// ```
-pub fn build_multi_producer<E, W, F>(size: usize, event_factory: F, wait_strategy: W)
--> MPBuilder<NC, E, W, MultiProducerBarrier>
+pub fn build_multi_producer<E, W, F>(
+    size: usize,
+    event_factory: F,
+    wait_strategy: W,
+) -> MPBuilder<NC, E, W, MultiProducerBarrier>
 where
-	F: FnMut() -> E,
-	E: 'static + Send + Sync,
-	W: 'static + WaitStrategy,
+    F: FnMut() -> E,
+    E: 'static + Send + Sync,
+    W: 'static + WaitStrategy,
 {
-	let producer_barrier  = Arc::new(MultiProducerBarrier::new(size));
-	let dependent_barrier = Arc::clone(&producer_barrier);
-	MPBuilder::new(size, event_factory, wait_strategy, producer_barrier, dependent_barrier)
+    let producer_barrier = Arc::new(MultiProducerBarrier::new(size));
+    let dependent_barrier = Arc::clone(&producer_barrier);
+    MPBuilder::new(
+        size,
+        event_factory,
+        wait_strategy,
+        producer_barrier,
+        dependent_barrier,
+    )
 }
 
 /// The processor's thread name and CPU affinity can be set via the builders that implement this trait.
@@ -132,128 +155,144 @@ where
 ///    .build();
 ///# }
 /// ```
-pub trait ProcessorSettings<E, W>: Sized {
-	#[doc(hidden)]
-	fn shared(&mut self) -> &mut Shared<E, W>;
+pub trait ProcessorSettings<E, W>: Sized
+where
+    W: WaitStrategy,
+{
+    #[doc(hidden)]
+    fn shared(&mut self) -> &mut Shared<E, W>;
 
-	/// Pin processor thread on the core with `id` for the next added event handler.
-	/// Outputs an error on stderr if the thread could not be pinned.
-	fn pin_at_core(mut self, id: usize) -> Self {
-		self.shared().pin_at_core(id);
-		self
-	}
+    /// Pin processor thread on the core with `id` for the next added event handler.
+    /// Outputs an error on stderr if the thread could not be pinned.
+    fn pin_at_core(mut self, id: usize) -> Self {
+        self.shared().pin_at_core(id);
+        self
+    }
 
-	/// Set a name for the processor thread for the next added event handler.
-	fn thread_name(mut self, name: &'static str) -> Self {
-		self.shared().thread_named(name);
-		self
-	}
+    /// Set a name for the processor thread for the next added event handler.
+    fn thread_name(mut self, name: &'static str) -> Self {
+        self.shared().thread_named(name);
+        self
+    }
 }
 
 trait Builder<E, W, B>: ProcessorSettings<E, W>
 where
-	E: 'static + Send + Sync,
-	B: 'static + Barrier,
-	W: 'static + WaitStrategy,
+    E: 'static + Send + Sync,
+    B: 'static + Barrier,
+    W: 'static + WaitStrategy,
 {
-	fn add_event_handler<EH>(&mut self, event_handler: EH)
-	where
-		EH: 'static + Send + FnMut(&E, Sequence, bool)
-	{
-		let barrier            = self.dependent_barrier();
-		let (cursor, consumer) = start_processor(event_handler, self.shared(), barrier);
-		self.shared().add_consumer_and_cursor(consumer, cursor);
-	}
+    fn add_event_handler<EH>(&mut self, event_handler: EH)
+    where
+        EH: 'static + Send + FnMut(&E, Sequence, bool),
+    {
+        let barrier = self.dependent_barrier();
+        let (cursor, consumer) = start_processor(event_handler, self.shared(), barrier);
+        self.shared().add_consumer_and_cursor(consumer, cursor);
+    }
 
-	fn get_event_poller(&mut self) -> EventPoller<E, B> {
-		let cursor = Arc::new(Cursor::new(-1)); // Initially, the consumer has not read slot 0 yet.
-		self.shared().add_cursor(Arc::clone(&cursor));
+    fn get_event_poller(&mut self) -> EventPoller<E, B> {
+        let cursor = Arc::new(Cursor::new(-1)); // Initially, the consumer has not read slot 0 yet.
+        self.shared().add_cursor(Arc::clone(&cursor));
 
-		EventPoller::new(
-			Arc::clone(&self.shared().ring_buffer),
-			Arc::clone(&self.dependent_barrier()),
-			Arc::clone(&self.shared().shutdown_at_sequence),
-			cursor,
-		)
-	}
+        EventPoller::new(
+            Arc::clone(&self.shared().ring_buffer),
+            Arc::clone(&self.dependent_barrier()),
+            Arc::clone(&self.shared().shutdown_at_sequence),
+            cursor,
+        )
+    }
 
-	fn add_event_handler_with_state<EH, S, IS>(&mut self, event_handler: EH, initialize_state: IS)
-	where
-		EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
-		IS: 'static + Send + FnOnce() -> S,
-	{
-		let barrier            = self.dependent_barrier();
-		let (cursor, consumer) = start_processor_with_state(event_handler, self.shared(), barrier, initialize_state);
-		self.shared().add_consumer_and_cursor(consumer, cursor);
-	}
+    fn add_event_handler_with_state<EH, S, IS>(&mut self, event_handler: EH, initialize_state: IS)
+    where
+        EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
+        IS: 'static + Send + FnOnce() -> S,
+    {
+        let barrier = self.dependent_barrier();
+        let (cursor, consumer) =
+            start_processor_with_state(event_handler, self.shared(), barrier, initialize_state);
+        self.shared().add_consumer_and_cursor(consumer, cursor);
+    }
 
-	fn dependent_barrier(&self) -> Arc<B>;
+    fn dependent_barrier(&self) -> Arc<B>;
 }
 
 #[doc(hidden)]
-pub struct Shared<E, W> {
-	pub(crate) shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
-	pub(crate) ring_buffer:          Arc<RingBuffer<E>>,
-	pub(crate) consumers:            Vec<Consumer>,
-	current_consumer_cursors:        Option<Vec<Arc<Cursor>>>,
-	pub(crate) wait_strategy:        W,
-	pub(crate) thread_context:       ThreadContext,
+pub struct Shared<E, W>
+where
+    W: crate::wait_strategies::WaitStrategy,
+{
+    pub(crate) shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
+    pub(crate) ring_buffer: Arc<RingBuffer<E>>,
+    pub(crate) consumers: Vec<Consumer>,
+    current_consumer_cursors: Option<Vec<Arc<Cursor>>>,
+    pub(crate) notifier: W::Notifier,
+    pub(crate) wait_strategy: W,
+    pub(crate) thread_context: ThreadContext,
 }
 
-impl <E, W> Shared<E, W> {
-	fn new<F>(size: usize, event_factory: F, wait_strategy: W) -> Self
-	where
-		F: FnMut() -> E
-	{
-		let ring_buffer              = Arc::new(RingBuffer::new(size, event_factory));
-		let shutdown_at_sequence     = Arc::new(CachePadded::new(AtomicI64::new(NONE)));
-		let current_consumer_cursors = Some(vec![]);
+impl<E, W> Shared<E, W>
+where
+    W: crate::wait_strategies::WaitStrategy,
+{
+    fn new<F>(size: usize, event_factory: F, wait_strategy: W) -> Self
+    where
+        F: FnMut() -> E,
+    {
+        let notifier = wait_strategy.notifier();
+        let ring_buffer = Arc::new(RingBuffer::new(size, event_factory));
+        let shutdown_at_sequence = Arc::new(CachePadded::new(AtomicI64::new(NONE)));
+        let current_consumer_cursors = Some(vec![]);
 
-		Self {
-			ring_buffer,
-			wait_strategy,
-			shutdown_at_sequence,
-			current_consumer_cursors,
-			consumers: vec![],
-			thread_context: ThreadContext::default(),
-		}
-	}
+        Self {
+            ring_buffer,
+            notifier,
+            wait_strategy,
+            shutdown_at_sequence,
+            current_consumer_cursors,
+            consumers: vec![],
+            thread_context: ThreadContext::default(),
+        }
+    }
 
-	fn add_consumer_and_cursor(&mut self, consumer: Consumer, cursor: Arc<Cursor>) {
-		self.consumers.push(consumer);
-		self.add_cursor(cursor);
-	}
+    fn add_consumer_and_cursor(&mut self, consumer: Consumer, cursor: Arc<Cursor>) {
+        self.consumers.push(consumer);
+        self.add_cursor(cursor);
+    }
 
-	fn add_cursor(&mut self, cursor: Arc<Cursor>) {
-		self.current_consumer_cursors.as_mut().unwrap().push(cursor);
-	}
+    fn add_cursor(&mut self, cursor: Arc<Cursor>) {
+        self.current_consumer_cursors.as_mut().unwrap().push(cursor);
+    }
 
-	fn pin_at_core(&mut self, id: usize) {
-		cpu_has_core_else_panic(id);
-		self.thread_context.affinity = Some(CoreId { id } );
-	}
+    fn pin_at_core(&mut self, id: usize) {
+        cpu_has_core_else_panic(id);
+        self.thread_context.affinity = Some(CoreId { id });
+    }
 
-	fn thread_named(&mut self, name: &'static str) {
-		self.thread_context.name = Some(name.to_owned());
-	}
+    fn thread_named(&mut self, name: &'static str) {
+        self.thread_context.name = Some(name.to_owned());
+    }
 }
 
 #[derive(Default)]
 pub(crate) struct ThreadContext {
-	affinity: Option<CoreId>,
-	name:     Option<String>,
-	id:       usize,
+    affinity: Option<CoreId>,
+    name: Option<String>,
+    id: usize,
 }
 
 impl ThreadContext {
-	pub(crate) fn name(&mut self) -> String {
-		self.name.take().or_else(|| {
-			self.id += 1;
-			Some(format!("processor-{}", self.id))
-		}).unwrap()
-	}
+    pub(crate) fn name(&mut self) -> String {
+        self.name
+            .take()
+            .or_else(|| {
+                self.id += 1;
+                Some(format!("processor-{}", self.id))
+            })
+            .unwrap()
+    }
 
-	pub(crate) fn affinity(&mut self) -> Option<CoreId> {
-		self.affinity.take()
-	}
+    pub(crate) fn affinity(&mut self) -> Option<CoreId> {
+        self.affinity.take()
+    }
 }

--- a/src/builder/multi.rs
+++ b/src/builder/multi.rs
@@ -4,235 +4,330 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
-use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::EventPoller, MultiConsumerBarrier, SingleConsumerBarrier}, producer::multi::{MultiProducer, MultiProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
+use crate::{
+    barrier::Barrier,
+    builder::ProcessorSettings,
+    consumer::{
+        event_poller::EventPoller, MultiConsumerBarrier, MultiConsumerDependentsBarrier,
+        SingleConsumerBarrier,
+    },
+    producer::multi::{MultiProducer, MultiProducerBarrier},
+    wait_strategies::WaitStrategy,
+    DependentSequence, Sequence,
+};
 
 use super::{Builder, Shared, MC, NC, SC};
 
 /// First step in building a Disruptor with a [MultiProducer].
-pub struct MPBuilder<State, E, W, B> {
-	state:             PhantomData<State>,
-	shared:            Shared<E, W>,
-	producer_barrier:  Arc<MultiProducerBarrier>,
-	dependent_barrier: Arc<B>,
+pub struct MPBuilder<State, E, W, B>
+where
+    W: WaitStrategy,
+{
+    state: PhantomData<State>,
+    shared: Shared<E, W>,
+    producer_barrier: Arc<MultiProducerBarrier>,
+    dependent_barrier: Arc<B>,
 }
 
-impl<S, E, W, B> ProcessorSettings<E, W> for MPBuilder<S, E, W, B> {
-	fn shared(&mut self) -> &mut Shared<E, W> {
-		&mut self.shared
-	}
+impl<S, E, W, B> ProcessorSettings<E, W> for MPBuilder<S, E, W, B>
+where
+    W: WaitStrategy,
+{
+    fn shared(&mut self) -> &mut Shared<E, W> {
+        &mut self.shared
+    }
 }
 
 impl<S, E, W, B> Builder<E, W, B> for MPBuilder<S, E, W, B>
 where
-	E: 'static + Send + Sync,
-	W: 'static + WaitStrategy,
-	B: 'static + Barrier,
+    E: 'static + Send + Sync,
+    W: 'static + WaitStrategy,
+    B: 'static + Barrier,
 {
-	fn dependent_barrier(&self) -> Arc<B> {
-		Arc::clone(&self.dependent_barrier)
-	}
+    fn dependent_barrier(&self) -> Arc<B> {
+        Arc::clone(&self.dependent_barrier)
+    }
 }
 
-impl <E, W, B> MPBuilder<NC, E, W, B>
+impl<E, W, B> MPBuilder<NC, E, W, B>
 where
-	E: 'static + Send + Sync,
-	W: 'static + WaitStrategy,
-	B: 'static + Barrier,
+    E: 'static + Send + Sync,
+    W: 'static + WaitStrategy,
+    B: 'static + Barrier,
 {
-	pub(super) fn new<F>(size: usize, event_factory: F, wait_strategy: W, producer_barrier: Arc<MultiProducerBarrier>, dependent_barrier: Arc<B>) -> Self
-	where
-		F: FnMut() -> E
-	{
-		let shared = Shared::new(size, event_factory, wait_strategy);
-		Self {
-			state: PhantomData,
-			shared,
-			producer_barrier,
-			dependent_barrier,
-		}
-	}
+    pub(super) fn new<F>(
+        size: usize,
+        event_factory: F,
+        wait_strategy: W,
+        producer_barrier: Arc<MultiProducerBarrier>,
+        dependent_barrier: Arc<B>,
+    ) -> Self
+    where
+        F: FnMut() -> E,
+    {
+        let shared = Shared::new(size, event_factory, wait_strategy);
+        Self {
+            state: PhantomData,
+            shared,
+            producer_barrier,
+            dependent_barrier,
+        }
+    }
 
-	/// Get an EventPoller.
-	pub fn event_poller(mut self) -> (EventPoller<E, B>, MPBuilder<SC, E, W, B>) {
-		let event_poller = self.get_event_poller();
+    /// Get an EventPoller.
+    pub fn event_poller(mut self) -> (EventPoller<E, B>, MPBuilder<SC, E, W, B>) {
+        let event_poller = self.get_event_poller();
 
-		(event_poller,
-		MPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		})
-	}
+        (
+            event_poller,
+            MPBuilder {
+                state: PhantomData,
+                shared: self.shared,
+                producer_barrier: self.producer_barrier,
+                dependent_barrier: self.dependent_barrier,
+            },
+        )
+    }
 
-	/// Add an event handler.
-	pub fn handle_events_with<EH>(mut self, event_handler: EH) -> MPBuilder<SC, E, W, B>
-	where
-		EH: 'static + Send + FnMut(&E, Sequence, bool)
-	{
-		self.add_event_handler(event_handler);
-		MPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		}
-	}
+    /// Add an event handler.
+    pub fn handle_events_with<EH>(mut self, event_handler: EH) -> MPBuilder<SC, E, W, B>
+    where
+        EH: 'static + Send + FnMut(&E, Sequence, bool),
+    {
+        self.add_event_handler(event_handler);
+        MPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier: self.dependent_barrier,
+        }
+    }
 
-	/// Add an event handler with state.
-	pub fn handle_events_and_state_with<EH, S, IS>(mut self, event_handler: EH, initialize_state: IS) -> MPBuilder<SC, E, W, B>
-	where
-		EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
-		IS: 'static + Send + FnOnce() -> S
-	{
-		self.add_event_handler_with_state(event_handler, initialize_state);
-		MPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		}
-	}
+    /// Add an event handler with state.
+    pub fn handle_events_and_state_with<EH, S, IS>(
+        mut self,
+        event_handler: EH,
+        initialize_state: IS,
+    ) -> MPBuilder<SC, E, W, B>
+    where
+        EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
+        IS: 'static + Send + FnOnce() -> S,
+    {
+        self.add_event_handler_with_state(event_handler, initialize_state);
+        MPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier: self.dependent_barrier,
+        }
+    }
 }
 
-impl <E, W, B> MPBuilder<SC, E, W, B>
+impl<E, W, B> MPBuilder<SC, E, W, B>
 where
-	E: 'static + Send + Sync,
-	W: 'static + WaitStrategy,
-	B: 'static + Barrier,
+    E: 'static + Send + Sync,
+    W: 'static + WaitStrategy,
+    B: 'static + Barrier,
 {
-	/// Get an EventPoller.
-	pub fn event_poller(mut self) -> (EventPoller<E, B>, MPBuilder<MC, E, W, B>) {
-		let event_poller = self.get_event_poller();
+    /// Get an EventPoller.
+    pub fn event_poller(mut self) -> (EventPoller<E, B>, MPBuilder<MC, E, W, B>) {
+        let event_poller = self.get_event_poller();
 
-		(event_poller,
-		MPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		})
-	}
+        (
+            event_poller,
+            MPBuilder {
+                state: PhantomData,
+                shared: self.shared,
+                producer_barrier: self.producer_barrier,
+                dependent_barrier: self.dependent_barrier,
+            },
+        )
+    }
 
-	/// Add an event handler.
-	pub fn handle_events_with<EH>(mut self, event_handler: EH) -> MPBuilder<MC, E, W, B>
-	where
-		EH: 'static + Send + FnMut(&E, Sequence, bool)
-	{
-		self.add_event_handler(event_handler);
-		MPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		}
-	}
+    /// Add an event handler.
+    pub fn handle_events_with<EH>(mut self, event_handler: EH) -> MPBuilder<MC, E, W, B>
+    where
+        EH: 'static + Send + FnMut(&E, Sequence, bool),
+    {
+        self.add_event_handler(event_handler);
+        MPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier: self.dependent_barrier,
+        }
+    }
 
-	/// Add an event handler with state.
-	pub fn handle_events_and_state_with<EH, S, IS>(mut self, event_handler: EH, initialize_state: IS) -> MPBuilder<MC, E, W, B>
-	where
-		EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
-		IS: 'static + Send + FnOnce() -> S
-	{
-		self.add_event_handler_with_state(event_handler, initialize_state);
-		MPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		}
-	}
+    /// Add an event handler with state.
+    pub fn handle_events_and_state_with<EH, S, IS>(
+        mut self,
+        event_handler: EH,
+        initialize_state: IS,
+    ) -> MPBuilder<MC, E, W, B>
+    where
+        EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
+        IS: 'static + Send + FnOnce() -> S,
+    {
+        self.add_event_handler_with_state(event_handler, initialize_state);
+        MPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier: self.dependent_barrier,
+        }
+    }
 
-	/// Complete the (concurrent) consumption of events so far and let new consumers process
-	/// events after all previous consumers have read them.
-	pub fn and_then(mut self) -> MPBuilder<NC, E, W, SingleConsumerBarrier> {
-		// Guaranteed to be present by construction.
-		let consumer_cursors  = self.shared().current_consumer_cursors.as_mut().unwrap();
-		let dependent_barrier = Arc::new(SingleConsumerBarrier::new(consumer_cursors.remove(0)));
+    /// Complete the (concurrent) consumption of events so far and let new consumers process
+    /// events after all previous consumers have read them.
+    pub fn and_then(mut self) -> MPBuilder<NC, E, W, SingleConsumerBarrier> {
+        // Guaranteed to be present by construction.
+        let consumer_cursors = self.shared().current_consumer_cursors.as_mut().unwrap();
+        let dependent_barrier = Arc::new(SingleConsumerBarrier::new(consumer_cursors.remove(0)));
 
-		MPBuilder {
-			state:            PhantomData,
-			shared:           self.shared,
-			producer_barrier: self.producer_barrier,
-			dependent_barrier,
-		}
-	}
+        MPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier,
+        }
+    }
 
-	/// Finish the build and get a [`MultiProducer`].
-	pub fn build(mut self) -> MultiProducer<E, SingleConsumerBarrier> {
-		let mut consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
-		// Guaranteed to be present by construction.
-		let consumer_barrier     = SingleConsumerBarrier::new(consumer_cursors.remove(0));
-		MultiProducer::new(
-			self.shared.shutdown_at_sequence,
-			self.shared.ring_buffer,
-			self.producer_barrier,
-			self.shared.consumers,
-			consumer_barrier)
-	}
+    /// Complete consumption so far and gate the next stage on the current consumer plus extra sequences.
+    pub fn and_then_with_dependents(
+        mut self,
+        gating: Vec<Arc<DependentSequence>>,
+    ) -> MPBuilder<NC, E, W, MultiConsumerDependentsBarrier> {
+        let consumer_cursors = self
+            .shared()
+            .current_consumer_cursors
+            .replace(vec![])
+            .unwrap();
+        let dependent_barrier = Arc::new(MultiConsumerDependentsBarrier::new(
+            consumer_cursors,
+            gating,
+        ));
+
+        MPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier,
+        }
+    }
+
+    /// Finish the build and get a [`MultiProducer`].
+    pub fn build(mut self) -> MultiProducer<E, SingleConsumerBarrier, W> {
+        let mut consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
+        // Guaranteed to be present by construction.
+        let consumer_barrier = SingleConsumerBarrier::new(consumer_cursors.remove(0));
+        MultiProducer::new(
+            self.shared.shutdown_at_sequence,
+            self.shared.ring_buffer,
+            self.producer_barrier,
+            self.shared.consumers,
+            consumer_barrier,
+            self.shared.notifier.clone(),
+        )
+    }
 }
 
-impl <E, W, B> MPBuilder<MC, E, W, B>
+impl<E, W, B> MPBuilder<MC, E, W, B>
 where
-	E: 'static + Send + Sync,
-	W: 'static + WaitStrategy,
-	B: 'static + Barrier,
+    E: 'static + Send + Sync,
+    W: 'static + WaitStrategy,
+    B: 'static + Barrier,
 {
-	/// Get an EventPoller.
-	pub fn event_poller(mut self) -> (EventPoller<E, B>, MPBuilder<MC, E, W, B>) {
-		let event_poller = self.get_event_poller();
+    /// Get an EventPoller.
+    pub fn event_poller(mut self) -> (EventPoller<E, B>, MPBuilder<MC, E, W, B>) {
+        let event_poller = self.get_event_poller();
 
-		(event_poller,
-		MPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		})
-	}
+        (
+            event_poller,
+            MPBuilder {
+                state: PhantomData,
+                shared: self.shared,
+                producer_barrier: self.producer_barrier,
+                dependent_barrier: self.dependent_barrier,
+            },
+        )
+    }
 
-	/// Add an event handler.
-	pub fn handle_events_with<EH>(mut self, event_handler: EH) -> MPBuilder<MC, E, W, B>
-	where
-		EH: 'static + Send + FnMut(&E, Sequence, bool)
-	{
-		self.add_event_handler(event_handler);
-		self
-	}
+    /// Add an event handler.
+    pub fn handle_events_with<EH>(mut self, event_handler: EH) -> MPBuilder<MC, E, W, B>
+    where
+        EH: 'static + Send + FnMut(&E, Sequence, bool),
+    {
+        self.add_event_handler(event_handler);
+        self
+    }
 
-	/// Add an event handler with state.
-	pub fn handle_events_and_state_with<EH, S, IS>(mut self, event_handler: EH, initialize_state: IS) -> MPBuilder<MC, E, W, B>
-	where
-		EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
-		IS: 'static + Send + FnOnce() -> S
-	{
-		self.add_event_handler_with_state(event_handler, initialize_state);
-		self
-	}
+    /// Add an event handler with state.
+    pub fn handle_events_and_state_with<EH, S, IS>(
+        mut self,
+        event_handler: EH,
+        initialize_state: IS,
+    ) -> MPBuilder<MC, E, W, B>
+    where
+        EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
+        IS: 'static + Send + FnOnce() -> S,
+    {
+        self.add_event_handler_with_state(event_handler, initialize_state);
+        self
+    }
 
-	/// Complete the (concurrent) consumption of events so far and let new consumers process
-	/// events after all previous consumers have read them.
-	pub fn and_then(mut self) -> MPBuilder<NC, E, W, MultiConsumerBarrier> {
-		let consumer_cursors  = self.shared().current_consumer_cursors.replace(vec![]).unwrap();
-		let dependent_barrier = Arc::new(MultiConsumerBarrier::new(consumer_cursors));
+    /// Complete the (concurrent) consumption of events so far and let new consumers process
+    /// events after all previous consumers have read them.
+    pub fn and_then(mut self) -> MPBuilder<NC, E, W, MultiConsumerBarrier> {
+        let consumer_cursors = self
+            .shared()
+            .current_consumer_cursors
+            .replace(vec![])
+            .unwrap();
+        let dependent_barrier = Arc::new(MultiConsumerBarrier::new(consumer_cursors));
 
-		MPBuilder {
-			state:            PhantomData,
-			shared:           self.shared,
-			producer_barrier: self.producer_barrier,
-			dependent_barrier,
-		}
-	}
+        MPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier,
+        }
+    }
 
-	/// Finish the build and get a [`MultiProducer`].
-	pub fn build(mut self) -> MultiProducer<E, MultiConsumerBarrier> {
-		let consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
-		let consumer_barrier = MultiConsumerBarrier::new(consumer_cursors);
-		MultiProducer::new(
-			self.shared.shutdown_at_sequence,
-			self.shared.ring_buffer,
-			self.producer_barrier,
-			self.shared.consumers,
-			consumer_barrier)
-	}
+    /// Complete consumption of events so far and gate the next stage on the slowest consumer *and*
+    /// the provided gating sequences (e.g., flushed WAL offset).
+    pub fn and_then_with_dependents(
+        mut self,
+        gating: Vec<Arc<DependentSequence>>,
+    ) -> MPBuilder<NC, E, W, MultiConsumerDependentsBarrier> {
+        let consumer_cursors = self
+            .shared()
+            .current_consumer_cursors
+            .replace(vec![])
+            .unwrap();
+        let dependent_barrier = Arc::new(MultiConsumerDependentsBarrier::new(
+            consumer_cursors,
+            gating,
+        ));
+
+        MPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier,
+        }
+    }
+
+    /// Finish the build and get a [`MultiProducer`].
+    pub fn build(mut self) -> MultiProducer<E, MultiConsumerBarrier, W> {
+        let consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
+        let consumer_barrier = MultiConsumerBarrier::new(consumer_cursors);
+        MultiProducer::new(
+            self.shared.shutdown_at_sequence,
+            self.shared.ring_buffer,
+            self.producer_barrier,
+            self.shared.consumers,
+            consumer_barrier,
+            self.shared.notifier.clone(),
+        )
+    }
 }

--- a/src/builder/single.rs
+++ b/src/builder/single.rs
@@ -4,235 +4,330 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
-use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::EventPoller, MultiConsumerBarrier, SingleConsumerBarrier}, producer::single::{SingleProducer, SingleProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
+use crate::{
+    barrier::Barrier,
+    builder::ProcessorSettings,
+    consumer::{
+        event_poller::EventPoller, MultiConsumerBarrier, MultiConsumerDependentsBarrier,
+        SingleConsumerBarrier,
+    },
+    producer::single::{SingleProducer, SingleProducerBarrier},
+    wait_strategies::WaitStrategy,
+    DependentSequence, Sequence,
+};
 
 use super::{Builder, Shared, MC, NC, SC};
 
 /// First step in building a Disruptor with a [SingleProducer].
-pub struct SPBuilder<State, E, W, B> {
-	state:             PhantomData<State>,
-	shared:            Shared<E, W>,
-	producer_barrier:  Arc<SingleProducerBarrier>,
-	dependent_barrier: Arc<B>,
+pub struct SPBuilder<State, E, W, B>
+where
+    W: WaitStrategy,
+{
+    state: PhantomData<State>,
+    shared: Shared<E, W>,
+    producer_barrier: Arc<SingleProducerBarrier>,
+    dependent_barrier: Arc<B>,
 }
 
-impl<E, W, B, S> ProcessorSettings<E, W> for SPBuilder<S, E, W, B> {
-	fn shared(&mut self) -> &mut Shared<E, W> {
-		&mut self.shared
-	}
+impl<E, W, B, S> ProcessorSettings<E, W> for SPBuilder<S, E, W, B>
+where
+    W: WaitStrategy,
+{
+    fn shared(&mut self) -> &mut Shared<E, W> {
+        &mut self.shared
+    }
 }
 
 impl<E, W, B, S> Builder<E, W, B> for SPBuilder<S, E, W, B>
 where
-	E: 'static + Send + Sync,
-	W: 'static + WaitStrategy,
-	B: 'static + Barrier,
+    E: 'static + Send + Sync,
+    W: 'static + WaitStrategy,
+    B: 'static + Barrier,
 {
-	fn dependent_barrier(&self) -> Arc<B> {
-		Arc::clone(&self.dependent_barrier)
-	}
+    fn dependent_barrier(&self) -> Arc<B> {
+        Arc::clone(&self.dependent_barrier)
+    }
 }
 
-impl <E, W, B> SPBuilder<NC, E, W, B>
+impl<E, W, B> SPBuilder<NC, E, W, B>
 where
-	E: 'static + Send + Sync,
-	W: 'static + WaitStrategy,
-	B: 'static + Barrier,
+    E: 'static + Send + Sync,
+    W: 'static + WaitStrategy,
+    B: 'static + Barrier,
 {
-	pub(super) fn new<F>(size: usize, event_factory: F, wait_strategy: W, producer_barrier: Arc<SingleProducerBarrier>, dependent_barrier: Arc<B>) -> Self
-	where
-		F: FnMut() -> E
-	{
-		let shared = Shared::new(size, event_factory, wait_strategy);
-		Self {
-			state: PhantomData,
-			shared,
-			producer_barrier,
-			dependent_barrier,
-		}
-	}
+    pub(super) fn new<F>(
+        size: usize,
+        event_factory: F,
+        wait_strategy: W,
+        producer_barrier: Arc<SingleProducerBarrier>,
+        dependent_barrier: Arc<B>,
+    ) -> Self
+    where
+        F: FnMut() -> E,
+    {
+        let shared = Shared::new(size, event_factory, wait_strategy);
+        Self {
+            state: PhantomData,
+            shared,
+            producer_barrier,
+            dependent_barrier,
+        }
+    }
 
-	/// Get an EventPoller.
-	pub fn event_poller(mut self) -> (EventPoller<E, B>, SPBuilder<SC, E, W, B>) {
-		let event_poller = self.get_event_poller();
+    /// Get an EventPoller.
+    pub fn event_poller(mut self) -> (EventPoller<E, B>, SPBuilder<SC, E, W, B>) {
+        let event_poller = self.get_event_poller();
 
-		(event_poller,
-		SPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		})
-	}
+        (
+            event_poller,
+            SPBuilder {
+                state: PhantomData,
+                shared: self.shared,
+                producer_barrier: self.producer_barrier,
+                dependent_barrier: self.dependent_barrier,
+            },
+        )
+    }
 
-	/// Add an event handler.
-	pub fn handle_events_with<EH>(mut self, event_handler: EH) -> SPBuilder<SC, E, W, B>
-	where
-		EH: 'static + Send + FnMut(&E, Sequence, bool)
-	{
-		self.add_event_handler(event_handler);
-		SPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		}
-	}
+    /// Add an event handler.
+    pub fn handle_events_with<EH>(mut self, event_handler: EH) -> SPBuilder<SC, E, W, B>
+    where
+        EH: 'static + Send + FnMut(&E, Sequence, bool),
+    {
+        self.add_event_handler(event_handler);
+        SPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier: self.dependent_barrier,
+        }
+    }
 
-	/// Add an event handler with state.
-	pub fn handle_events_and_state_with<EH, S, IS>(mut self, event_handler: EH, initialize_state: IS) -> SPBuilder<SC, E, W, B>
-	where
-		EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
-		IS: 'static + Send + FnOnce() -> S,
-	{
-		self.add_event_handler_with_state(event_handler, initialize_state);
-		SPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		}
-	}
+    /// Add an event handler with state.
+    pub fn handle_events_and_state_with<EH, S, IS>(
+        mut self,
+        event_handler: EH,
+        initialize_state: IS,
+    ) -> SPBuilder<SC, E, W, B>
+    where
+        EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
+        IS: 'static + Send + FnOnce() -> S,
+    {
+        self.add_event_handler_with_state(event_handler, initialize_state);
+        SPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier: self.dependent_barrier,
+        }
+    }
 }
 
-impl <E, W, B> SPBuilder<SC, E, W, B>
+impl<E, W, B> SPBuilder<SC, E, W, B>
 where
-	E: 'static + Send + Sync,
-	W: 'static + WaitStrategy,
-	B: 'static + Barrier,
+    E: 'static + Send + Sync,
+    W: 'static + WaitStrategy,
+    B: 'static + Barrier,
 {
-	/// Finish the build and get a [`SingleProducer`].
-	pub fn build(mut self) -> SingleProducer<E, SingleConsumerBarrier> {
-		let mut consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
-		// Guaranteed to be present by construction.
-		let consumer_barrier     = SingleConsumerBarrier::new(consumer_cursors.remove(0));
-		SingleProducer::new(
-			self.shared.shutdown_at_sequence,
-			self.shared.ring_buffer,
-			self.producer_barrier,
-			self.shared.consumers,
-		consumer_barrier)
-	}
+    /// Finish the build and get a [`SingleProducer`].
+    pub fn build(mut self) -> SingleProducer<E, SingleConsumerBarrier, W> {
+        let mut consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
+        // Guaranteed to be present by construction.
+        let consumer_barrier = SingleConsumerBarrier::new(consumer_cursors.remove(0));
+        SingleProducer::new(
+            self.shared.shutdown_at_sequence,
+            self.shared.ring_buffer,
+            self.producer_barrier,
+            self.shared.consumers,
+            consumer_barrier,
+            self.shared.notifier.clone(),
+        )
+    }
 
-	/// Get an EventPoller.
-	pub fn event_poller(mut self) -> (EventPoller<E, B>, SPBuilder<MC, E, W, B>) {
-		let event_poller = self.get_event_poller();
+    /// Get an EventPoller.
+    pub fn event_poller(mut self) -> (EventPoller<E, B>, SPBuilder<MC, E, W, B>) {
+        let event_poller = self.get_event_poller();
 
-		(event_poller,
-		SPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		})
-	}
+        (
+            event_poller,
+            SPBuilder {
+                state: PhantomData,
+                shared: self.shared,
+                producer_barrier: self.producer_barrier,
+                dependent_barrier: self.dependent_barrier,
+            },
+        )
+    }
 
-	/// Complete the (concurrent) consumption of events so far and let new consumers process
-	/// events after all previous consumers have read them.
-	pub fn and_then(mut self) -> SPBuilder<NC, E, W, SingleConsumerBarrier> {
-		// Guaranteed to be present by construction.
-		let consumer_cursors  = self.shared().current_consumer_cursors.as_mut().unwrap();
-		let dependent_barrier = Arc::new(SingleConsumerBarrier::new(consumer_cursors.remove(0)));
+    /// Complete the (concurrent) consumption of events so far and let new consumers process
+    /// events after all previous consumers have read them.
+    pub fn and_then(mut self) -> SPBuilder<NC, E, W, SingleConsumerBarrier> {
+        // Guaranteed to be present by construction.
+        let consumer_cursors = self.shared().current_consumer_cursors.as_mut().unwrap();
+        let dependent_barrier = Arc::new(SingleConsumerBarrier::new(consumer_cursors.remove(0)));
 
-		SPBuilder {
-			state:            PhantomData,
-			shared:           self.shared,
-			producer_barrier: self.producer_barrier,
-			dependent_barrier,
-		}
-	}
+        SPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier,
+        }
+    }
 
-	/// Add an event handler.
-	pub fn handle_events_with<EH>(mut self, event_handler: EH) -> SPBuilder<MC, E, W, B>
-	where
-		EH: 'static + Send + FnMut(&E, Sequence, bool)
-	{
-		self.add_event_handler(event_handler);
-		SPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		}
-	}
+    /// Add an event handler.
+    pub fn handle_events_with<EH>(mut self, event_handler: EH) -> SPBuilder<MC, E, W, B>
+    where
+        EH: 'static + Send + FnMut(&E, Sequence, bool),
+    {
+        self.add_event_handler(event_handler);
+        SPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier: self.dependent_barrier,
+        }
+    }
 
-	/// Add an event handler with state.
-	pub fn handle_events_and_state_with<EH, S, IS>(mut self, event_handler: EH, initalize_state: IS) -> SPBuilder<MC, E, W, B>
-	where
-		EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
-		IS: 'static + Send + FnOnce() -> S,
-	{
-		self.add_event_handler_with_state(event_handler, initalize_state);
-		SPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		}
-	}
+    /// Add an event handler with state.
+    pub fn handle_events_and_state_with<EH, S, IS>(
+        mut self,
+        event_handler: EH,
+        initalize_state: IS,
+    ) -> SPBuilder<MC, E, W, B>
+    where
+        EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
+        IS: 'static + Send + FnOnce() -> S,
+    {
+        self.add_event_handler_with_state(event_handler, initalize_state);
+        SPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier: self.dependent_barrier,
+        }
+    }
+
+    /// Complete consumption so far and gate the next stage on the current consumer plus extra sequences.
+    pub fn and_then_with_dependents(
+        mut self,
+        gating: Vec<Arc<DependentSequence>>,
+    ) -> SPBuilder<NC, E, W, MultiConsumerDependentsBarrier> {
+        let consumer_cursors = self
+            .shared()
+            .current_consumer_cursors
+            .replace(vec![])
+            .unwrap();
+        let dependent_barrier = Arc::new(MultiConsumerDependentsBarrier::new(
+            consumer_cursors,
+            gating,
+        ));
+
+        SPBuilder {
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+            dependent_barrier,
+        }
+    }
 }
 
-impl <E, W, B> SPBuilder<MC, E, W, B>
+impl<E, W, B> SPBuilder<MC, E, W, B>
 where
-	E: 'static + Send + Sync,
-	W: 'static + WaitStrategy,
-	B: 'static + Barrier,
+    E: 'static + Send + Sync,
+    W: 'static + WaitStrategy,
+    B: 'static + Barrier,
 {
-	/// Get an EventPoller.
-	pub fn event_poller(mut self) -> (EventPoller<E, B>, SPBuilder<MC, E, W, B>) {
-		let event_poller = self.get_event_poller();
+    /// Get an EventPoller.
+    pub fn event_poller(mut self) -> (EventPoller<E, B>, SPBuilder<MC, E, W, B>) {
+        let event_poller = self.get_event_poller();
 
-		(event_poller,
-		SPBuilder {
-			state:             PhantomData,
-			shared:            self.shared,
-			producer_barrier:  self.producer_barrier,
-			dependent_barrier: self.dependent_barrier,
-		})
-	}
+        (
+            event_poller,
+            SPBuilder {
+                state: PhantomData,
+                shared: self.shared,
+                producer_barrier: self.producer_barrier,
+                dependent_barrier: self.dependent_barrier,
+            },
+        )
+    }
 
-	/// Add an event handler.
-	pub fn handle_events_with<EH>(mut self, event_handler: EH) -> SPBuilder<MC, E, W, B>
-	where
-		EH: 'static + Send + FnMut(&E, Sequence, bool)
-	{
-		self.add_event_handler(event_handler);
-		self
-	}
+    /// Add an event handler.
+    pub fn handle_events_with<EH>(mut self, event_handler: EH) -> SPBuilder<MC, E, W, B>
+    where
+        EH: 'static + Send + FnMut(&E, Sequence, bool),
+    {
+        self.add_event_handler(event_handler);
+        self
+    }
 
-	/// Add an event handler with state.
-	pub fn handle_events_and_state_with<EH, S, IS>(mut self, event_handler: EH, initialize_state: IS) -> SPBuilder<MC, E, W, B>
-	where
-		EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
-		IS: 'static + Send + FnOnce() -> S,
-	{
-		self.add_event_handler_with_state(event_handler, initialize_state);
-		self
-	}
+    /// Add an event handler with state.
+    pub fn handle_events_and_state_with<EH, S, IS>(
+        mut self,
+        event_handler: EH,
+        initialize_state: IS,
+    ) -> SPBuilder<MC, E, W, B>
+    where
+        EH: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
+        IS: 'static + Send + FnOnce() -> S,
+    {
+        self.add_event_handler_with_state(event_handler, initialize_state);
+        self
+    }
 
-	/// Complete the (concurrent) consumption of events so far and let new consumers process
-	/// events after all previous consumers have read them.
-	pub fn and_then(mut self) -> SPBuilder<NC, E, W, MultiConsumerBarrier> {
-		let consumer_cursors  = self.shared().current_consumer_cursors.replace(vec![]).unwrap();
-		let dependent_barrier = Arc::new(MultiConsumerBarrier::new(consumer_cursors));
+    /// Complete the (concurrent) consumption of events so far and let new consumers process
+    /// events after all previous consumers have read them.
+    pub fn and_then(mut self) -> SPBuilder<NC, E, W, MultiConsumerBarrier> {
+        let consumer_cursors = self
+            .shared()
+            .current_consumer_cursors
+            .replace(vec![])
+            .unwrap();
+        let dependent_barrier = Arc::new(MultiConsumerBarrier::new(consumer_cursors));
 
-		SPBuilder {
-			dependent_barrier,
-			state:            PhantomData,
-			shared:           self.shared,
-			producer_barrier: self.producer_barrier,
-		}
-	}
+        SPBuilder {
+            dependent_barrier,
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+        }
+    }
 
-	/// Finish the build and get a [`SingleProducer`].
-	pub fn build(mut self) -> SingleProducer<E, MultiConsumerBarrier> {
-		let consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
-		let consumer_barrier = MultiConsumerBarrier::new(consumer_cursors);
-		SingleProducer::new(
-			self.shared.shutdown_at_sequence,
-			self.shared.ring_buffer,
-			self.producer_barrier,
-			self.shared.consumers,
-			consumer_barrier)
-	}
+    /// Complete the (concurrent) consumption of events so far and gate the next stage on the slowest
+    /// consumer *and* the provided gating sequences.
+    pub fn and_then_with_dependents(
+        mut self,
+        gating: Vec<Arc<DependentSequence>>,
+    ) -> SPBuilder<NC, E, W, MultiConsumerDependentsBarrier> {
+        let consumer_cursors = self
+            .shared()
+            .current_consumer_cursors
+            .replace(vec![])
+            .unwrap();
+        let dependent_barrier = Arc::new(MultiConsumerDependentsBarrier::new(
+            consumer_cursors,
+            gating,
+        ));
+
+        SPBuilder {
+            dependent_barrier,
+            state: PhantomData,
+            shared: self.shared,
+            producer_barrier: self.producer_barrier,
+        }
+    }
+
+    /// Finish the build and get a [`SingleProducer`].
+    pub fn build(mut self) -> SingleProducer<E, MultiConsumerBarrier, W> {
+        let consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
+        let consumer_barrier = MultiConsumerBarrier::new(consumer_cursors);
+        SingleProducer::new(
+            self.shared.shutdown_at_sequence,
+            self.shared.ring_buffer,
+            self.producer_barrier,
+            self.shared.consumers,
+            consumer_barrier,
+            self.shared.notifier.clone(),
+        )
+    }
 }

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1,181 +1,263 @@
-use std::{sync::{atomic::{fence, AtomicI64, Ordering}, Arc}, thread::{self, JoinHandle}};
-use crossbeam_utils::CachePadded;
+use std::{
+    sync::Arc,
+    thread::{self, JoinHandle},
+};
 
-use crate::{affinity::set_affinity_if_defined, barrier::Barrier, builder::Shared, cursor::Cursor, wait_strategies::WaitStrategy, Sequence};
+use crate::{
+    affinity::set_affinity_if_defined,
+    barrier::Barrier,
+    builder::Shared,
+    cursor::Cursor,
+    sequence::DependentSequence,
+    wait_strategies::{WaitOutcome, WaitStrategy, Waiter},
+    Sequence,
+};
 
 pub mod event_poller;
 
 #[doc(hidden)]
 pub struct Consumer {
-	join_handle: Option<JoinHandle<()>>,
+    join_handle: Option<JoinHandle<()>>,
 }
 
 impl Consumer {
-	pub(crate) fn new(join_handle: JoinHandle<()>) -> Self {
-		Self {
-			join_handle: Some(join_handle),
-		}
-	}
+    pub(crate) fn new(join_handle: JoinHandle<()>) -> Self {
+        Self {
+            join_handle: Some(join_handle),
+        }
+    }
 
-	pub(crate) fn join(&mut self) {
-		if let Some(h) = self.join_handle.take() { h.join().expect("Consumer should not panic.") }
-	}
+    pub(crate) fn join(&mut self) {
+        if let Some(h) = self.join_handle.take() {
+            h.join().expect("Consumer should not panic.")
+        }
+    }
 }
 
 /// Barrier tracking a single consumer.
 pub struct SingleConsumerBarrier {
-	cursor: Arc<Cursor>
+    cursor: Arc<Cursor>,
 }
 
 /// Barrier tracking the minimum sequence of a group of consumers.
 pub struct MultiConsumerBarrier {
-	cursors: Vec<Arc<Cursor>>
+    cursors: Vec<Arc<Cursor>>,
+}
+
+/// Barrier that tracks minimum of a group of consumers plus optional external gating sequences.
+pub struct MultiConsumerDependentsBarrier {
+    cursors: Vec<Arc<Cursor>>,
+    dependent_sequences: Vec<Arc<DependentSequence>>,
 }
 
 impl SingleConsumerBarrier {
-	pub(crate) fn new(cursor: Arc<Cursor>) -> Self {
-		Self {
-			cursor
-		}
-	}
+    pub(crate) fn new(cursor: Arc<Cursor>) -> Self {
+        Self { cursor }
+    }
 }
 
 impl Barrier for SingleConsumerBarrier {
-	#[inline]
-	fn get_after(&self, _lower_bound: Sequence) -> Sequence {
-		self.cursor.relaxed_value()
-	}
+    #[inline]
+    fn get_after(&self, _lower_bound: Sequence) -> Sequence {
+        self.cursor.relaxed_value()
+    }
 }
 
 impl MultiConsumerBarrier {
-	pub(crate) fn new(cursors: Vec<Arc<Cursor>>) -> Self {
-		Self {
-			cursors
-		}
-	}
+    pub(crate) fn new(cursors: Vec<Arc<Cursor>>) -> Self {
+        Self { cursors }
+    }
 }
 
 impl Barrier for MultiConsumerBarrier {
-	/// Gets the available `Sequence` of the slowest consumer.
-	#[inline]
-	fn get_after(&self, _lower_bound: Sequence) -> Sequence {
-		self.cursors.iter().fold(i64::MAX, |min_sequence, cursor| {
-			let sequence = cursor.relaxed_value();
-			std::cmp::min(sequence, min_sequence)
-		})
-	}
+    /// Gets the available `Sequence` of the slowest consumer.
+    #[inline]
+    fn get_after(&self, _lower_bound: Sequence) -> Sequence {
+        self.cursors.iter().fold(i64::MAX, |min_sequence, cursor| {
+            let sequence = cursor.relaxed_value();
+            std::cmp::min(sequence, min_sequence)
+        })
+    }
 }
 
-pub(crate) fn start_processor<E, EP, W, B> (
-	mut event_handler: EP,
-	builder:           &mut Shared<E, W>,
-	barrier:           Arc<B>)
--> (Arc<Cursor>, Consumer)
-where
-	E:  'static + Send + Sync,
-	EP: 'static + Send + FnMut(&E, Sequence, bool),
-	W:  'static + WaitStrategy,
-	B:  'static + Barrier + Send + Sync,
-{
-	let consumer_cursor      = Arc::new(Cursor::new(-1));// Initially, the consumer has not read slot 0 yet.
-	let wait_strategy        = builder.wait_strategy;
-	let ring_buffer          = Arc::clone(&builder.ring_buffer);
-	let shutdown_at_sequence = Arc::clone(&builder.shutdown_at_sequence);
-	let thread_name          = builder.thread_context.name();
-	let affinity             = builder.thread_context.affinity();
-	let thread_builder       = thread::Builder::new().name(thread_name.clone());
-	let join_handle          = {
-		let consumer_cursor = Arc::clone(&consumer_cursor);
-		thread_builder.spawn(move || {
-			set_affinity_if_defined(affinity, thread_name.as_str());
-			let mut sequence = 0;
-			while let Some(available) = wait_for_events(sequence, &shutdown_at_sequence, barrier.as_ref(), &wait_strategy) {
-				while available >= sequence { // Potentiel batch processing.
-					let end_of_batch = available == sequence;
-					// SAFETY: Now, we have (shared) read access to the event at `sequence`.
-					let event_ptr    = ring_buffer.get(sequence);
-					let event        = unsafe { & *event_ptr };
-					event_handler(event, sequence, end_of_batch);
-					// Update next sequence to read.
-					sequence += 1;
-				}
-				// Signal to producers or later consumers that we're done processing `sequence - 1`.
-				consumer_cursor.store(sequence - 1);
-			}
-		}).expect("Should spawn thread.")
-	};
-
-	let consumer = Consumer::new(join_handle);
-	(consumer_cursor, consumer)
+impl MultiConsumerDependentsBarrier {
+    pub(crate) fn new(
+        cursors: Vec<Arc<Cursor>>,
+        dependent_sequences: Vec<Arc<DependentSequence>>,
+    ) -> Self {
+        Self {
+            cursors,
+            dependent_sequences,
+        }
+    }
 }
 
-pub(crate) fn start_processor_with_state<E, EP, W, B, S, IS> (
-	mut event_handler: EP,
-	builder:           &mut Shared<E, W>,
-	barrier:           Arc<B>,
-	initialize_state:  IS)
--> (Arc<Cursor>, Consumer)
-where
-	E:  'static + Send + Sync,
-	IS: 'static + Send + FnOnce() -> S,
-	EP: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
-	W:  'static + WaitStrategy,
-	B:  'static + Barrier + Send + Sync,
-{
-	let consumer_cursor      = Arc::new(Cursor::new(-1));// Initially, the consumer has not read slot 0 yet.
-	let wait_strategy        = builder.wait_strategy;
-	let ring_buffer          = Arc::clone(&builder.ring_buffer);
-	let shutdown_at_sequence = Arc::clone(&builder.shutdown_at_sequence);
-	let thread_name          = builder.thread_context.name();
-	let affinity             = builder.thread_context.affinity();
-	let thread_builder       = thread::Builder::new().name(thread_name.clone());
-	let join_handle          = {
-		let consumer_cursor = Arc::clone(&consumer_cursor);
-		thread_builder.spawn(move || {
-			set_affinity_if_defined(affinity, thread_name.as_str());
-			let mut sequence = 0;
-			let mut state    = initialize_state();
-			while let Some(available_sequence) = wait_for_events(sequence, &shutdown_at_sequence, barrier.as_ref(), &wait_strategy) {
-				while available_sequence >= sequence { // Potentiel batch processing.
-					let end_of_batch = available_sequence == sequence;
-					// SAFETY: Now, we have (shared) read access to the event at `sequence`.
-					let event_ptr    = ring_buffer.get(sequence);
-					let event        = unsafe { & *event_ptr };
-					event_handler(&mut state, event, sequence, end_of_batch);
-					// Update next sequence to read.
-					sequence += 1;
-				}
-				// Signal to producers or later consumers that we're done processing `sequence - 1`.
-				consumer_cursor.store(sequence - 1);
-			}
-		}).expect("Should spawn thread.")
-	};
-
-	let consumer = Consumer::new(join_handle);
-	(consumer_cursor, consumer)
+impl Barrier for MultiConsumerDependentsBarrier {
+    #[inline]
+    fn get_after(&self, _lower_bound: Sequence) -> Sequence {
+        let consumer_min = self.cursors.iter().fold(i64::MAX, |min_sequence, cursor| {
+            let sequence = cursor.relaxed_value();
+            std::cmp::min(sequence, min_sequence)
+        });
+        self.dependent_sequences
+            .iter()
+            .fold(consumer_min, |min_sequence, seq| {
+                let sequence = seq.get();
+                std::cmp::min(sequence, min_sequence)
+            })
+    }
 }
 
-#[inline]
-fn wait_for_events<B, W>(
-	sequence:             Sequence,
-	shutdown_at_sequence: &CachePadded<AtomicI64>,
-	barrier:              &B,
-	wait_strategy:        &W
-)
--> Option<Sequence>
+pub(crate) fn start_processor<E, EP, W, B>(
+    mut event_handler: EP,
+    builder: &mut Shared<E, W>,
+    barrier: Arc<B>,
+) -> (Arc<Cursor>, Consumer)
 where
-	B: Barrier + Send + Sync,
-	W: WaitStrategy,
+    E: 'static + Send + Sync,
+    EP: 'static + Send + FnMut(&E, Sequence, bool),
+    W: 'static + WaitStrategy,
+    B: 'static + Barrier + Send + Sync,
 {
-	let mut available = barrier.get_after(sequence);
-	while available < sequence {
-		// If publisher(s) are done publishing events we're done when we've seen the last event.
-		if shutdown_at_sequence.load(Ordering::Relaxed) == sequence {
-			return None;
-		}
-		wait_strategy.wait_for(sequence);
-		available = barrier.get_after(sequence);
-	}
-	fence(Ordering::Acquire);
-	Some(available)
+    let consumer_cursor = Arc::new(Cursor::new(-1)); // Initially, the consumer has not read slot 0 yet.
+    let wait_strategy = builder.wait_strategy.clone();
+    let ring_buffer = Arc::clone(&builder.ring_buffer);
+    let shutdown_at_sequence = Arc::clone(&builder.shutdown_at_sequence);
+    let thread_name = builder.thread_context.name();
+    let affinity = builder.thread_context.affinity();
+    let thread_builder = thread::Builder::new().name(thread_name.clone());
+    let join_handle = {
+        let consumer_cursor = Arc::clone(&consumer_cursor);
+        thread_builder
+            .spawn(move || {
+                set_affinity_if_defined(affinity, thread_name.as_str());
+                let mut waiter = wait_strategy.new_waiter();
+                let mut sequence = 0;
+                loop {
+                    let available = match waiter.wait_for(
+                        sequence,
+                        barrier.as_ref(),
+                        shutdown_at_sequence.as_ref(),
+                    ) {
+                        WaitOutcome::Available { upper } => upper,
+                        WaitOutcome::Shutdown => break,
+                        WaitOutcome::Timeout => continue,
+                    };
+                    while available >= sequence {
+                        // Potential batch processing.
+                        let end_of_batch = available == sequence;
+                        // SAFETY: Now, we have (shared) read access to the event at `sequence`.
+                        let event_ptr = ring_buffer.get(sequence);
+                        let event = unsafe { &*event_ptr };
+                        event_handler(event, sequence, end_of_batch);
+                        // Update next sequence to read.
+                        sequence += 1;
+                    }
+                    // Signal to producers or later consumers that we're done processing `sequence - 1`.
+                    consumer_cursor.store(sequence - 1);
+                }
+            })
+            .expect("Should spawn thread.")
+    };
+
+    let consumer = Consumer::new(join_handle);
+    (consumer_cursor, consumer)
+}
+
+pub(crate) fn start_processor_with_state<E, EP, W, B, S, IS>(
+    mut event_handler: EP,
+    builder: &mut Shared<E, W>,
+    barrier: Arc<B>,
+    initialize_state: IS,
+) -> (Arc<Cursor>, Consumer)
+where
+    E: 'static + Send + Sync,
+    IS: 'static + Send + FnOnce() -> S,
+    EP: 'static + Send + FnMut(&mut S, &E, Sequence, bool),
+    W: 'static + WaitStrategy,
+    B: 'static + Barrier + Send + Sync,
+{
+    let consumer_cursor = Arc::new(Cursor::new(-1)); // Initially, the consumer has not read slot 0 yet.
+    let wait_strategy = builder.wait_strategy.clone();
+    let ring_buffer = Arc::clone(&builder.ring_buffer);
+    let shutdown_at_sequence = Arc::clone(&builder.shutdown_at_sequence);
+    let thread_name = builder.thread_context.name();
+    let affinity = builder.thread_context.affinity();
+    let thread_builder = thread::Builder::new().name(thread_name.clone());
+    let join_handle = {
+        let consumer_cursor = Arc::clone(&consumer_cursor);
+        thread_builder
+            .spawn(move || {
+                set_affinity_if_defined(affinity, thread_name.as_str());
+                let mut waiter = wait_strategy.new_waiter();
+                let mut sequence = 0;
+                let mut state = initialize_state();
+                loop {
+                    let available_sequence = match waiter.wait_for(
+                        sequence,
+                        barrier.as_ref(),
+                        shutdown_at_sequence.as_ref(),
+                    ) {
+                        WaitOutcome::Available { upper } => upper,
+                        WaitOutcome::Shutdown => break,
+                        WaitOutcome::Timeout => continue,
+                    };
+                    while available_sequence >= sequence {
+                        // Potential batch processing.
+                        let end_of_batch = available_sequence == sequence;
+                        // SAFETY: Now, we have (shared) read access to the event at `sequence`.
+                        let event_ptr = ring_buffer.get(sequence);
+                        let event = unsafe { &*event_ptr };
+                        event_handler(&mut state, event, sequence, end_of_batch);
+                        // Update next sequence to read.
+                        sequence += 1;
+                    }
+                    // Signal to producers or later consumers that we're done processing `sequence - 1`.
+                    consumer_cursor.store(sequence - 1);
+                }
+            })
+            .expect("Should spawn thread.")
+    };
+
+    let consumer = Consumer::new(join_handle);
+    (consumer_cursor, consumer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multi_consumer_gating_barrier_respects_external_gate() {
+        let c1 = Arc::new(Cursor::new(-1));
+        let c2 = Arc::new(Cursor::new(-1));
+        c1.store(10);
+        c2.store(12);
+
+        let gating_low = Arc::new(DependentSequence::with_value(5));
+        let gating_high = Arc::new(DependentSequence::with_value(20));
+
+        let barrier =
+            MultiConsumerDependentsBarrier::new(vec![c1.clone(), c2.clone()], vec![gating_low]);
+        assert_eq!(5, barrier.get_after(0));
+
+        let barrier = MultiConsumerDependentsBarrier::new(vec![c1, c2], vec![gating_high]);
+        assert_eq!(10, barrier.get_after(0));
+    }
+
+    #[test]
+    fn dependents_barrier_clamps_when_dependent_moves_backwards() {
+        let c1 = Arc::new(Cursor::new(-1));
+        let c2 = Arc::new(Cursor::new(-1));
+        c1.store(8);
+        c2.store(9);
+
+        let dep = Arc::new(DependentSequence::with_value(7));
+        let barrier = MultiConsumerDependentsBarrier::new(vec![c1.clone(), c2.clone()], vec![dep.clone()]);
+        assert_eq!(7, barrier.get_after(0));
+
+        // Move the dependent sequence backwards; barrier should clamp to the new minimum.
+        dep.set(3);
+        assert_eq!(3, barrier.get_after(0));
+    }
 }

--- a/src/consumer/event_poller.rs
+++ b/src/consumer/event_poller.rs
@@ -1,13 +1,16 @@
-use std::{sync::{atomic::{fence, AtomicI64, Ordering}, Arc}};
+use crate::{barrier::Barrier, cursor::Cursor, ringbuffer::RingBuffer, Sequence};
 use crossbeam_utils::CachePadded;
+use std::sync::{
+    atomic::{fence, AtomicI64, Ordering},
+    Arc,
+};
 use thiserror::Error;
-use crate::{cursor::Cursor, barrier::Barrier, ringbuffer::RingBuffer, Sequence};
 
 /// Represents an EventPoller that can be used to poll events from the ring buffer.
 /// Use the EventPoller when you want to control your own thread
 /// (instead of letting the Disruptor manage it).
 /// The EventPoller supports batch reading and can be used to process events in a loop.
-/// 
+///
 /// ```
 ///# use disruptor::*;
 ///#
@@ -38,21 +41,21 @@ use crate::{cursor::Cursor, barrier::Barrier, ringbuffer::RingBuffer, Sequence};
 /// }
 /// ```
 pub struct EventPoller<E, B> {
-	ring_buffer:          Arc<RingBuffer<E>>,
-	dependent_barrier:    Arc<B>,
-	shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
-	cursor:               Arc<Cursor>,
+    ring_buffer: Arc<RingBuffer<E>>,
+    dependent_barrier: Arc<B>,
+    shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
+    cursor: Arc<Cursor>,
 }
 
 /// Error types that can occur if polling is unsuccessful.
 #[derive(Debug, Error, PartialEq)]
 pub enum Polling {
-	/// Indicates that there are no events available to process.
-	#[error("No available events.")]
-	NoEvents,
-	/// Indicates that the Disruptor has been shut down.
-	#[error("Disruptor is shut down.")]
-	Shutdown,
+    /// Indicates that there are no events available to process.
+    #[error("No available events.")]
+    NoEvents,
+    /// Indicates that the Disruptor has been shut down.
+    #[error("Disruptor is shut down.")]
+    Shutdown,
 }
 
 /// Guards the available events that can be processed when using the EventPoller API.
@@ -60,9 +63,9 @@ pub enum Polling {
 /// will signal to the `Disruptor` that the reading is completed. This will allow other consumers or
 /// producers to advance.
 pub struct EventGuard<'p, E, B> {
-	parent:    &'p mut EventPoller<E, B>,
-	sequence:  Sequence,
-	available: Sequence,
+    parent: &'p mut EventPoller<E, B>,
+    sequence: Sequence,
+    available: Sequence,
 }
 
 /// The Iterator is implemented for the `&mut EventGuard` to bind the returned
@@ -71,74 +74,139 @@ pub struct EventGuard<'p, E, B> {
 /// could hold on to a reference to a en Event after the drop method was run for the
 /// `EventGuard` and a publisher could write to the immutable reference - UB.)
 impl<'g, E, B> Iterator for &'g mut EventGuard<'_, E, B> {
-	type Item = &'g E;
+    type Item = &'g E;
 
-	fn next(&mut self) -> Option<Self::Item> {
-		if self.sequence > self.available {
-			return None;
-		}
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.sequence > self.available {
+            return None;
+        }
 
-		// SAFETY: The Guard is authorized to read up to and including `available` sequence.
-		let event_ptr = self.parent.ring_buffer.get(self.sequence);
-		let event     = unsafe { &*event_ptr };
-		self.sequence += 1;
-		Some(event)
-	}
+        // SAFETY: The Guard is authorized to read up to and including `available` sequence.
+        let event_ptr = self.parent.ring_buffer.get(self.sequence);
+        let event = unsafe { &*event_ptr };
+        self.sequence += 1;
+        Some(event)
+    }
 }
 
 impl<E, B> ExactSizeIterator for &mut EventGuard<'_, E, B> {
-	/// Returns the number of events available to read.
-	fn len(&self) -> usize {
-		(self.available - self.sequence + 1) as usize
-	}
+    /// Returns the number of events available to read.
+    fn len(&self) -> usize {
+        (self.available - self.sequence + 1) as usize
+    }
 }
 
 impl<E, B> Drop for EventGuard<'_, E, B> {
-	fn drop(&mut self) {
-		// Signal to producers or later consumers that we're done processing `available` sequence.
-		// Note, not all events in the range have to have been read.
-		// (I.e. client code can skip reading any number events.)
-		self.parent.cursor.store(self.available);
-	}
+    fn drop(&mut self) {
+        // Signal to producers or later consumers that we're done processing `available` sequence.
+        // Note, not all events in the range have to have been read.
+        // (I.e. client code can skip reading any number events.)
+        self.parent.cursor.store(self.available);
+    }
 }
 
 impl<E, B> EventPoller<E, B>
 where
-	B: Barrier,
+    B: Barrier,
 {
-	pub(crate) fn new(
-		ring_buffer:          Arc<RingBuffer<E>>,
-		dependent_barrier:    Arc<B>,
-		shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
-		cursor:               Arc<Cursor>,
-	) -> Self {
-		Self {
-			ring_buffer,
-			dependent_barrier,
-			shutdown_at_sequence,
-			cursor,
-		}
-	}
+    pub(crate) fn new(
+        ring_buffer: Arc<RingBuffer<E>>,
+        dependent_barrier: Arc<B>,
+        shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
+        cursor: Arc<Cursor>,
+    ) -> Self {
+        Self {
+            ring_buffer,
+            dependent_barrier,
+            shutdown_at_sequence,
+            cursor,
+        }
+    }
 
-	/// Returns the next available event or an error if no events are available or the Disruptor is shut down.
-	/// This method does not block; it will return immediately.
-	pub fn poll(&mut self) -> Result<EventGuard<'_, E, B>, Polling> {
-		let sequence = self.cursor.relaxed_value() + 1;
+    /// Returns the next available event or an error if no events are available or the Disruptor is shut down.
+    /// This method does not block; it will return immediately.
+    pub fn poll(&mut self) -> Result<EventGuard<'_, E, B>, Polling> {
+        let sequence = self.cursor.relaxed_value() + 1;
 
-		if sequence == self.shutdown_at_sequence.load(Ordering::Relaxed) {
-			return Err(Polling::Shutdown);
-		}
+        if sequence == self.shutdown_at_sequence.load(Ordering::Relaxed) {
+            return Err(Polling::Shutdown);
+        }
 
-		let available = self.dependent_barrier.get_after(sequence);
-		if available < sequence {
-			return Err(Polling::NoEvents);
-		}
-		fence(Ordering::Acquire);
+        let available = self.dependent_barrier.get_after(sequence);
+        if available < sequence {
+            return Err(Polling::NoEvents);
+        }
+        fence(Ordering::Acquire);
 
-		Ok(EventGuard {
-			parent: self,
-			sequence,
-			available,
-		})
-	}
+        Ok(EventGuard {
+            parent: self,
+            sequence,
+            available,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consumer::SingleConsumerBarrier;
+    use crate::ringbuffer::RingBuffer;
+
+    #[test]
+    fn poller_observes_manual_shutdown_without_producer_drop() {
+        #[derive(Debug)]
+        struct Event;
+
+        let ring_buffer = Arc::new(RingBuffer::new(2, || Event));
+        let cursor = Arc::new(Cursor::new(-1));
+        let shutdown = Arc::new(CachePadded::new(AtomicI64::new(-1)));
+        let barrier = Arc::new(SingleConsumerBarrier::new(Arc::clone(&cursor)));
+
+        let mut poller = EventPoller::new(
+            ring_buffer,
+            barrier,
+            Arc::clone(&shutdown),
+            Arc::clone(&cursor),
+        );
+
+        // Signal shutdown as if producer had advanced to sequence 0.
+        shutdown.store(0, Ordering::Relaxed);
+        assert_eq!(poller.poll().err(), Some(Polling::Shutdown));
+    }
+
+    #[test]
+    fn poller_exits_on_shutdown_race() {
+        #[derive(Debug)]
+        struct Event;
+
+        let ring_buffer = Arc::new(RingBuffer::new(2, || Event));
+        let cursor = Arc::new(Cursor::new(-1));
+        let shutdown = Arc::new(CachePadded::new(AtomicI64::new(-1)));
+        let barrier = Arc::new(SingleConsumerBarrier::new(Arc::clone(&cursor)));
+
+        let mut poller = EventPoller::new(
+            ring_buffer,
+            barrier,
+            Arc::clone(&shutdown),
+            Arc::clone(&cursor),
+        );
+
+        let shutdown_ref = shutdown.clone();
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            shutdown_ref.store(0, Ordering::Relaxed);
+        });
+
+        // Spin poll until shutdown is observed.
+        let mut saw_shutdown = false;
+        for _ in 0..10 {
+            if matches!(poller.poll(), Err(Polling::Shutdown)) {
+                saw_shutdown = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        handle.join().unwrap();
+        assert!(saw_shutdown, "poller should see shutdown promptly");
+    }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,51 +1,52 @@
-use std::sync::atomic::{AtomicI64, Ordering};
 use crossbeam_utils::CachePadded;
+use std::sync::atomic::{AtomicI64, Ordering};
 
 use crate::Sequence;
 
 pub(crate) struct Cursor {
-	counter: CachePadded<AtomicI64>
+    counter: CachePadded<AtomicI64>,
 }
 
 impl Cursor {
-	pub(crate) fn new(start_value: i64) -> Self {
-		Self {
-			counter: CachePadded::new(AtomicI64::new(start_value))
-		}
-	}
+    pub(crate) fn new(start_value: i64) -> Self {
+        Self {
+            counter: CachePadded::new(AtomicI64::new(start_value)),
+        }
+    }
 
-	#[inline]
-	pub(crate) fn compare_exchange(&self, current: Sequence, next: Sequence) -> Result<i64, i64> {
-		self.counter.compare_exchange(current, next, Ordering::AcqRel, Ordering::Relaxed)
-	}
+    #[inline]
+    pub(crate) fn compare_exchange(&self, current: Sequence, next: Sequence) -> Result<i64, i64> {
+        self.counter
+            .compare_exchange(current, next, Ordering::AcqRel, Ordering::Relaxed)
+    }
 
-	/// Stores `sequence` to the cursor with `Ordering::Release` semantics.
-	#[inline]
-	pub(crate) fn store(&self, sequence: Sequence) {
-		self.counter.store(sequence, Ordering::Release);
-	}
+    /// Stores `sequence` to the cursor with `Ordering::Release` semantics.
+    #[inline]
+    pub(crate) fn store(&self, sequence: Sequence) {
+        self.counter.store(sequence, Ordering::Release);
+    }
 
-	/// Retrieves the cursor value with `Ordering::Relaxed` semantics.
-	#[inline]
-	pub(crate) fn relaxed_value(&self) -> Sequence {
-		self.counter.load(Ordering::Relaxed)
-	}
+    /// Retrieves the cursor value with `Ordering::Relaxed` semantics.
+    #[inline]
+    pub(crate) fn relaxed_value(&self) -> Sequence {
+        self.counter.load(Ordering::Relaxed)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn cursor_operations() {
-		let cursor = Cursor::new(-1);
+    #[test]
+    fn cursor_operations() {
+        let cursor = Cursor::new(-1);
 
-		assert_eq!(cursor.compare_exchange(-1, 0).ok().unwrap(), -1);
-		assert_eq!(cursor.compare_exchange( 0, 1).ok().unwrap(),  0);
-		// Simulate other thread having updated the cursor.
-		assert_eq!(cursor.compare_exchange( 0, 1).err().unwrap(), 1);
+        assert_eq!(cursor.compare_exchange(-1, 0).ok().unwrap(), -1);
+        assert_eq!(cursor.compare_exchange(0, 1).ok().unwrap(), 0);
+        // Simulate other thread having updated the cursor.
+        assert_eq!(cursor.compare_exchange(0, 1).err().unwrap(), 1);
 
-		cursor.store(100);
-		assert_eq!(cursor.relaxed_value(), 100);
-	}
+        cursor.store(100);
+        assert_eq!(cursor.relaxed_value(), 100);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,787 +262,1224 @@
 /// The type for Sequence numbers in the Ring Buffer ([`i64`]).
 pub type Sequence = i64;
 
-pub mod wait_strategies;
-pub mod builder;
 mod affinity;
 mod barrier;
+pub mod builder;
 mod consumer;
 mod cursor;
-mod ringbuffer;
 mod producer;
+mod ringbuffer;
+mod sequence;
+pub mod wait_strategies;
 
-pub use crate::builder::{build_single_producer, build_multi_producer, ProcessorSettings};
-pub use crate::producer::{Producer, RingBufferFull, MissingFreeSlots};
-pub use crate::wait_strategies::{BusySpin, BusySpinWithSpinLoopHint};
-pub use crate::producer::{single::{SingleProducer, SingleProducerBarrier}, multi::{MultiProducer,  MultiProducerBarrier}};
-pub use crate::consumer::{SingleConsumerBarrier, MultiConsumerBarrier};
-pub use crate::consumer::event_poller::{EventPoller, Polling, EventGuard};
+pub use crate::builder::{build_multi_producer, build_single_producer, ProcessorSettings};
+pub use crate::consumer::event_poller::{EventGuard, EventPoller, Polling};
+pub use crate::consumer::{
+    MultiConsumerBarrier, MultiConsumerDependentsBarrier, SingleConsumerBarrier,
+};
+pub use crate::producer::{
+    multi::{MultiProducer, MultiProducerBarrier},
+    single::{SingleProducer, SingleProducerBarrier},
+};
+pub use crate::producer::{MissingFreeSlots, Producer, RingBufferFull};
+pub use crate::sequence::DependentSequence;
+pub use crate::wait_strategies::{BusySpin, BusySpinWithSpinLoopHint, YieldingWaitStrategy};
 
 #[cfg(test)]
 mod tests {
-	use std::rc::Rc;
-	use std::cell::RefCell;
-	use std::collections::HashSet;
-	use std::sync::atomic::AtomicBool;
-	use std::sync::atomic::Ordering::Relaxed;
-	use std::sync::{mpsc, Arc};
-	use std::thread;
-	use producer::MissingFreeSlots;
-	use super::*;
-
-	#[derive(Debug)]
-	struct Event {
-		num: i64,
-	}
-
-	fn factory() -> impl Fn() -> Event {
-		|| { Event { num: -1 }}
-	}
-
-	#[test]
-	#[should_panic(expected = "Size must be power of 2.")]
-	fn size_not_a_factor_of_2() {
-		build_single_producer(3, || { 0 }, BusySpin);
-	}
-
-	#[test]
-	fn spsc_full_ringbuffer() {
-		let (s, r)    = mpsc::channel();
-		let barrier   = Arc::new(AtomicBool::new(true));
-		let processor = {
-			let barrier = Arc::clone(&barrier);
-			move |e: &Event, _, _| {
-				while barrier.load(Relaxed) { /* Wait. */ }
-				s.send(e.num).expect("Should be able to send.");
-			}
-		};
-		let mut producer = build_single_producer(4, factory(), BusySpinWithSpinLoopHint)
-			.handle_events_with(processor)
-			.build();
-
-		for i in 0..4 {
-			producer.try_publish(|e| e.num = i).expect("Should publish");
-		}
-		// Now ring buffer is full.
-		assert_eq!(RingBufferFull, producer.try_publish(|e| e.num = 4).err().unwrap());
-		// And it stays full.
-		assert_eq!(RingBufferFull, producer.try_publish(|e| e.num = 4).err().unwrap());
-		// Until the processor continues reading events.
-		barrier.store(false, Relaxed);
-		producer.publish(|e| e.num = 4);
-
-		drop(producer);
-		let result: Vec<_> = r.iter().collect();
-		assert_eq!(result, [0, 1, 2, 3, 4]);
-	}
-
-	#[test]
-	fn mpsc_full_ringbuffer() {
-		let (s, r)    = mpsc::channel();
-		let barrier   = Arc::new(AtomicBool::new(true));
-		let processor = {
-			let barrier = Arc::clone(&barrier);
-			move |e: &Event, _, _| {
-				while barrier.load(Relaxed) { /* Wait. */ }
-				s.send(e.num).expect("Should be able to send.");
-			}
-		};
-		let mut producer1 = build_multi_producer(64, factory(), BusySpinWithSpinLoopHint)
-			.handle_events_with(processor)
-			.build();
-
-		let mut producer2 = producer1.clone();
-
-		for i in 0..64 {
-			producer1.try_publish(|e| e.num = i).expect("Should publish");
-		}
-
-		// Now ring buffer is full.
-		assert_eq!(RingBufferFull, producer1.try_publish(|e| e.num = 4).err().unwrap());
-		// And it is full also as seen from second producer.
-		assert_eq!(RingBufferFull, producer2.try_publish(|e| e.num = 4).err().unwrap());
-		// Until the processor continues reading events.
-		barrier.store(false, Relaxed);
-		producer1.publish(|e| e.num = 64);
-		producer2.publish(|e| e.num = 65);
-
-		drop(producer1);
-		drop(producer2);
-		let result: Vec<_> = r.iter().collect();
-		assert_eq!(result, (0..=65).into_iter().collect::<Vec<i64>>());
-	}
-
-	#[test]
-	fn spsc_insufficient_space_for_batch_publication() {
-		let (s, r)    = mpsc::channel();
-		let barrier   = Arc::new(AtomicBool::new(true));
-		let processor = {
-			let barrier = Arc::clone(&barrier);
-			move |e: &Event, _, _| {
-				while barrier.load(Relaxed) { /* Wait. */ }
-				s.send(e.num).expect("Should be able to send.");
-			}
-		};
-		let mut producer = build_single_producer(4, factory(), BusySpin)
-			.handle_events_with(processor)
-			.build();
-
-		for i in 0..2 {
-			producer.publish(|e| e.num = i);
-		}
-		assert_eq!(MissingFreeSlots(2),   producer.try_batch_publish(  4, |_iter| {} ).err().unwrap());
-		assert_eq!(MissingFreeSlots(100), producer.try_batch_publish(102, |_iter| {} ).err().unwrap());
-
-		barrier.store(false, Relaxed);
-		producer.try_batch_publish(2, |iter| {
-			for e in iter {
-				e.num = 2;
-			}
-		}).expect("Batch publication should now succeed.");
-
-		drop(producer);
-		let result: Vec<_> = r.iter().collect();
-		assert_eq!(result, [0, 1, 2, 2]);
-	}
-
-	#[test]
-	fn mpsc_insufficient_space_for_batch_publication() {
-		let (s, r)    = mpsc::channel();
-		let barrier   = Arc::new(AtomicBool::new(true));
-		let processor = {
-			let barrier = Arc::clone(&barrier);
-			move |e: &Event, _, _| {
-				while barrier.load(Relaxed) { /* Wait. */ }
-				s.send(e.num).expect("Should be able to send.");
-			}
-		};
-		let mut producer1 = build_multi_producer(64, factory(), BusySpin)
-			.handle_events_with(processor)
-			.build();
-		let mut producer2 = producer1.clone();
-
-		for i in 0..58 {
-			producer1.publish(|e| e.num = i);
-		}
-		assert_eq!(MissingFreeSlots(2),   producer1.try_batch_publish(  8, |_iter| {} ).err().unwrap());
-		assert_eq!(MissingFreeSlots(100), producer1.try_batch_publish(106, |_iter| {} ).err().unwrap());
-		assert_eq!(MissingFreeSlots(2),   producer2.try_batch_publish(  8, |_iter| {} ).err().unwrap());
-		assert_eq!(MissingFreeSlots(100), producer2.try_batch_publish(106, |_iter| {} ).err().unwrap());
-
-		barrier.store(false, Relaxed);
-		producer1.try_batch_publish(2, |iter| {
-			for e in iter {
-				e.num = 2;
-			}
-		}).expect("Batch publication should now succeed.");
-		producer2.try_batch_publish(2, |iter| {
-			for e in iter {
-				e.num = 3;
-			}
-		}).expect("Batch publication should now succeed.");
-
-		drop(producer1);
-		drop(producer2);
-		let mut result: Vec<_> = r.iter().collect();
-		result.sort();
-		// Initial events published.
-		let mut expected = (0..58).into_iter().collect::<Vec<i64>>();
-		// Now add the two successfull batch publications.
-		expected.push(2);
-		expected.push(2);
-		expected.push(3);
-		expected.push(3);
-		expected.sort();
-		assert_eq!(result, expected);
-	}
-
-	#[test]
-	fn spsc_disruptor() {
-		let (s, r)    = mpsc::channel();
-		let processor = move |e: &Event, _, _| {
-			s.send(e.num).expect("Should be able to send.");
-		};
-		let mut producer = build_single_producer(8, factory(), BusySpin)
-			.handle_events_with(processor)
-			.build();
-
-		thread::scope(|s| {
-			s.spawn(move || {
-				for i in 0..10 {
-					producer.publish(|e| e.num = i*i );
-				}
-			});
-		});
-
-		let result: Vec<_> = r.iter().collect();
-		assert_eq!(result, [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]);
-	}
-
-	#[cfg_attr(miri, ignore)]
-	#[test]
-	fn spsc_disruptor_with_pinned_and_named_thread() {
-		let (s, r)    = mpsc::channel();
-		let processor = move |e: &Event, _, _| {
-			s.send(e.num).expect("Should be able to send.");
-		};
-		let mut producer = build_single_producer(8, factory(), BusySpin)
-			.pin_at_core(0).thread_name("my-processor").handle_events_with(processor)
-			.build();
-
-		thread::scope(|s| {
-			s.spawn(move || {
-				for i in 0..10 {
-					producer.publish(|e| e.num = i*i );
-				}
-			});
-		});
-
-		let result: Vec<_> = r.iter().collect();
-		assert_eq!(result, [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]);
-	}
-
-	#[test]
-	fn spsc_disruptor_with_batch_publication() {
-		let (s, r)    = mpsc::channel();
-		let processor = move |e: &Event, _, _| {
-			s.send(e.num).expect("Should be able to send.");
-		};
-		let mut producer = build_single_producer(8, factory(), BusySpin)
-			.handle_events_with(processor)
-			.build();
-
-		let mut i = 0;
-		for _ in 0..3 {
-			producer.batch_publish(3, |iter| {
-				// We are guaranteed that the iterator will yield three elements:
-				assert_eq!((3, Some(3)), iter.size_hint());
-
-				// Publish.
-				for e in iter {
-					e.num = i*i;
-					i    += 1;
-				}
-			});
-		}
-		drop(producer);
-
-		let result: Vec<_> = r.iter().collect();
-		assert_eq!(result, [0, 1, 4, 9, 16, 25, 36, 49, 64]);
-	}
-
-	#[test]
-	fn spsc_disruptor_with_zero_batch_publication() {
-		let (s, r)    = mpsc::channel();
-		let processor = move |e: &Event, _, _| {
-			s.send(e.num).expect("Should be able to send.");
-		};
-		let mut producer = build_single_producer(8, factory(), BusySpin)
-			.handle_events_with(processor)
-			.build();
-
-		producer.batch_publish(0, |iter| {
-			for e in iter {
-				e.num = 1;
-			}
-		});
-		drop(producer);
-
-		let result: Vec<_> = r.iter().collect();
-		assert_eq!(result, []);
-	}
-
-	#[test]
-	fn spsc_disruptor_with_state() {
-		let (s, r)           = mpsc::channel();
-		let initialize_state = || { Rc::new(RefCell::new(0)) };
-		let processor        = move |state: &mut Rc<RefCell<i64>>, e: &Event, _, _| {
-			let mut ref_cell = state.borrow_mut();
-			*ref_cell       += e.num;
-			s.send(*ref_cell).expect("Should be able to send.");
-		};
-		let mut producer     = build_single_producer(8, factory(), BusySpin)
-			.handle_events_and_state_with(processor, initialize_state)
-			.build();
-
-		for i in 0..10 {
-			producer.publish(|e| e.num = i );
-		}
-
-		drop(producer);
-		let result: Vec<_> = r.iter().collect();
-		assert_eq!(result, [0, 1, 3, 6, 10, 15, 21, 28, 36, 45]);
-	}
-
-	#[test]
-	fn pipeline_of_two_spsc_disruptors() {
-		let (s, r)    = mpsc::channel();
-		let processor = move |e: &Event, _, _| {
-			s.send(e.num).expect("Should be able to send.");
-		};
-
-		// Last Disruptor.
-		let mut producer = build_single_producer(8, factory(), BusySpin)
-			.handle_events_with(processor)
-			.build();
-		let processor = move |e: &Event, _, _| {
-			producer.publish(|e2| e2.num = e.num );
-		};
-
-		// First Disruptor.
-		let mut producer = build_single_producer(8, factory(), BusySpin)
-			.handle_events_with(processor)
-			.build();
-		for i in 0..10 {
-			producer.publish(|e| e.num = i*i );
-		}
-
-		drop(producer);
-		let result: Vec<_> = r.iter().collect();
-		assert_eq!(result, [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]);
-	}
-
-	#[test]
-	fn multi_publisher_disruptor() {
-		let (s, r)    = mpsc::channel();
-		let processor = move |e: &Event, _, _| {
-			s.send(e.num).expect("Should be able to send.");
-		};
-
-		let mut producer1 = build_multi_producer(64, factory(), BusySpinWithSpinLoopHint)
-			.handle_events_with(processor)
-			.build();
-		let mut producer2 = producer1.clone();
-
-		let num_items = 100;
-
-		thread::scope(|s| {
-			s.spawn(move || {
-				for i in 0..num_items/2 {
-					producer1.publish(|e| e.num = i);
-				}
-			});
-
-			s.spawn(move || {
-				for i in (num_items/2)..num_items {
-					producer2.publish(|e| e.num = i);
-				}
-			});
-		});
-
-		let mut result: Vec<_> = r.iter().collect();
-		result.sort();
-
-		let expected: Vec<i64> = (0..num_items).collect();
-		assert_eq!(result, expected);
-	}
-
-	#[test]
-	fn multi_publisher_disruptor_with_batch_publication() {
-		let (s, r)    = mpsc::channel();
-		let processor = move |e: &Event, _, _| {
-			s.send(e.num).expect("Should be able to send.");
-		};
-
-		let mut producer1 = build_multi_producer(64, factory(), BusySpin)
-			.handle_events_with(processor)
-			.build();
-		let mut producer2 = producer1.clone();
-
-		let num_items  = 100_i64;
-		let batch_size = 5;
-
-		thread::scope(|s| {
-			s.spawn(move || {
-				for b in 0..(num_items/2)/batch_size {
-					producer1.batch_publish(batch_size as usize, |iter| {
-						for (i, e) in iter.enumerate() {
-							e.num = batch_size*b + i as i64;
-						}
-					});
-				}
-			});
-
-			s.spawn(move || {
-				for i in (num_items/2)..num_items {
-					producer2.publish(|e| e.num = i as i64);
-				}
-			});
-		});
-
-		let mut result: Vec<_> = r.iter().collect();
-		result.sort();
-
-		let expected: Vec<i64> = (0..num_items).collect();
-		assert_eq!(result, expected);
-	}
-
-	#[test]
-	fn spmc_with_concurrent_consumers() {
-		let (s, r) = mpsc::channel();
-
-		let processor1 = {
-			let s = s.clone();
-			move |e: &Event, _, _| { s.send(e.num + 1).unwrap(); }
-		};
-		let processor2 = {
-			let s = s.clone();
-			move |e: &Event, _, _| { s.send(e.num + 2).unwrap(); }
-		};
-		let processor3 = {
-			move |e: &Event, _, _| { s.send(e.num + 3).unwrap(); }
-		};
-
-		let builder      = build_single_producer(8, factory(), BusySpin);
-		let mut producer = builder
-			.handle_events_with(processor1)
-			.handle_events_with(processor2)
-			.handle_events_with(processor3)
-			.build();
-
-		producer.publish(|e| { e.num = 0; });
-		drop(producer);
-
-		let result: HashSet<i64> = r.iter().collect();
-		let expected = HashSet::from([1, 2, 3]);
-		assert_eq!(expected, result);
-	}
-
-	#[test]
-	fn spmc_with_dependent_consumers_and_some_with_state() {
-		let (s, r) = mpsc::channel();
-
-		let processor1 = {
-			let s = s.clone();
-			move |e: &Event, _, _| { s.send(e.num + 0).unwrap(); }
-		};
-		let processor2 = {
-			let s = s.clone();
-			move |state: &mut RefCell<i64>, e: &Event, _, _| {
-				*state.borrow_mut() += e.num;
-				s.send(*state.borrow() + 10).unwrap();
-			}
-		};
-		let processor3 = {
-			let s = s.clone();
-			move |e: &Event, _, _| { s.send(e.num + 2).unwrap(); }
-		};
-		let processor4 = {
-			let s = s.clone();
-			move |state: &mut RefCell<i64>, e: &Event, _, _| {
-				*state.borrow_mut() += e.num;
-				s.send(*state.borrow() + 20).unwrap();
-			}
-		};
-		let processor5 = {
-			let s = s.clone();
-			move |e: &Event, _, _| { s.send(e.num + 4).unwrap(); }
-		};
-		let processor6 = {
-			move |state: &mut RefCell<i64>, e: &Event, _, _| {
-				*state.borrow_mut() += e.num;
-				s.send(*state.borrow() + 30).unwrap();
-			}
-		};
-
-		let builder      = build_single_producer(8, factory(), BusySpin);
-
-		let mut producer = builder
-			.handle_events_with(processor1)
-			.handle_events_and_state_with(processor2, || { RefCell::new(0) })
-			.and_then()
-				.handle_events_with(processor3)
-				.handle_events_and_state_with(processor4, || { RefCell::new(0) })
-				.and_then()
-					.handle_events_with(processor5)
-					.handle_events_and_state_with(processor6, || { RefCell::new(0) })
-			.build();
-
-		producer.publish(|e| { e.num = 1; });
-		drop(producer);
-
-		let mut result: Vec<i64> = r.iter().collect();
-		result.sort();
-		assert_eq!(vec![1, 3, 5, 11, 21, 31], result);
-	}
-
-	#[test]
-	fn mpmc_with_dependent_consumers_and_some_with_state() {
-		let (s, r) = mpsc::channel();
-
-		let processor1 = {
-			let s = s.clone();
-			move |e: &Event, _, _| { s.send(e.num + 0).unwrap(); }
-		};
-		let processor2 = {
-			let s = s.clone();
-			move |state: &mut RefCell<i64>, e: &Event, _, _| {
-				*state.borrow_mut() += e.num;
-				s.send(*state.borrow() + 10).unwrap();
-			}
-		};
-		let processor3 = {
-			let s = s.clone();
-			move |e: &Event, _, _| { s.send(e.num + 2).unwrap(); }
-		};
-		let processor4 = {
-			let s = s.clone();
-			move |state: &mut RefCell<i64>, e: &Event, _, _| {
-				*state.borrow_mut() += e.num;
-				s.send(*state.borrow() + 20).unwrap();
-			}
-		};
-		let processor5 = {
-			let s = s.clone();
-			move |e: &Event, _, _| { s.send(e.num + 4).unwrap(); }
-		};
-		let processor6 = {
-			move |state: &mut RefCell<i64>, e: &Event, _, _| {
-				*state.borrow_mut() += e.num;
-				s.send(*state.borrow() + 30).unwrap();
-			}
-		};
-
-		let builder      = build_multi_producer(64, factory(), BusySpin);
-		let mut producer1 = builder
-			.handle_events_with(processor1)
-			.handle_events_and_state_with(processor2, || { RefCell::new(0) })
-			.and_then()
-				.handle_events_with(processor3)
-				.handle_events_and_state_with(processor4, || { RefCell::new(0) })
-				.and_then()
-					.handle_events_with(processor5)
-					.handle_events_and_state_with(processor6, || { RefCell::new(0) })
-			.build();
-
-		let mut producer2 = producer1.clone();
-
-		thread::scope(|s| {
-			s.spawn(move || {
-				producer1.publish(|e| e.num = 1);
-			});
-
-			s.spawn(move || {
-				producer2.publish(|e| e.num = 1);
-			});
-		});
-
-		let mut result: Vec<i64> = r.iter().collect();
-		result.sort();
-		assert_eq!(vec![1, 1, 3, 3, 5, 5, 11, 12, 21, 22, 31, 32], result);
-	}
-
-	#[test]
-	fn spmc_with_event_pollers() {
-		let builder       = build_single_producer(8, factory(), BusySpin);
-		let (mut ep1, b)  = builder.event_poller();
-		let (mut ep2, b)  = b.and_then().event_poller();
-		let (mut ep3, b)  = b.and_then().event_poller();
-		let mut producer  = b.build();
-
-		// Polling before publication should yield no events.
-		assert_eq!(ep1.poll().err(), Some(Polling::NoEvents));
-		assert_eq!(ep2.poll().err(), Some(Polling::NoEvents));
-		assert_eq!(ep3.poll().err(), Some(Polling::NoEvents));
-
-		// Publish two events.
-		producer.publish(|e| { e.num = 1; });
-		producer.publish(|e| { e.num = 2; });
-
-		let expected = vec![1, 2];
-
-		{// Only first poller sees events.
-			let mut guard_1 = ep1.poll().ok().unwrap();
-			assert_eq!(ep2.poll().err(), Some(Polling::NoEvents));
-			assert_eq!(ep3.poll().err(), Some(Polling::NoEvents));
-			assert_eq!(expected, guard_1.map(|e| e.num).collect::<Vec<_>>());
-		}
-
-		{// Now second poller sees events.
-			let mut guard_2 = ep2.poll().ok().unwrap();
-			assert_eq!(ep3.poll().err(), Some(Polling::NoEvents));
-			assert_eq!(expected, guard_2.map(|e| e.num).collect::<Vec<_>>());
-		}
-
-		{// Now third poller sees events.
-			let mut guard_3 = ep3.poll().ok().unwrap();
-			assert_eq!(expected, guard_3.map(|e| e.num).collect::<Vec<_>>());
-		}
-
-		// Dropping the producer should indicate shutdown to all pollers.
-		drop(producer);
-		assert_eq!(ep1.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep2.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep3.poll().err(), Some(Polling::Shutdown));
-	}
-
-	#[test]
-	fn mpmc_with_event_pollers() {
-		let builder       = build_multi_producer(64, factory(), BusySpin);
-		let (mut ep1, b)  = builder.event_poller();
-		let (mut ep2, b)  = b.and_then().event_poller();
-		let (mut ep3, b)  = b.and_then().event_poller();
-		let mut producer1 = b.build();
-		let mut producer2 = producer1.clone();
-
-		// Polling before publication should yield no events.
-		assert_eq!(ep1.poll().err(), Some(Polling::NoEvents));
-		assert_eq!(ep2.poll().err(), Some(Polling::NoEvents));
-		assert_eq!(ep3.poll().err(), Some(Polling::NoEvents));
-
-		// Publish two events.
-		producer1.publish(|e| { e.num = 1; });
-		producer2.publish(|e| { e.num = 2; });
-
-		let expected = HashSet::from([1, 2]);
-
-		{// Only first poller sees events.
-			let mut guard_1 = ep1.poll().ok().unwrap();
-			assert_eq!(ep2.poll().err(), Some(Polling::NoEvents));
-			assert_eq!(ep3.poll().err(), Some(Polling::NoEvents));
-			assert_eq!(expected, guard_1.map(|e| e.num).collect::<HashSet<_>>());
-		}
-
-		{// Now second poller sees events.
-			let mut guard_2 = ep2.poll().ok().unwrap();
-			assert_eq!(ep3.poll().err(), Some(Polling::NoEvents));
-			assert_eq!(expected, guard_2.map(|e| e.num).collect::<HashSet<_>>());
-		}
-
-		{// Now third poller sees events.
-			let mut guard_3 = ep3.poll().ok().unwrap();
-			assert_eq!(expected, guard_3.map(|e| e.num).collect::<HashSet<_>>());
-		}
-
-		// Dropping the producers should indicate shutdown to all pollers.
-		drop(producer1);
-		drop(producer2);
-		assert_eq!(ep1.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep2.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep3.poll().err(), Some(Polling::Shutdown));
-	}
-
-	#[test]
-	fn spmc_with_mixed_event_pollers_and_processors() {
-		let (s, r)       = mpsc::channel();
-		let processor1   = move |e: &Event, _, _| { s.send(e.num).unwrap(); };
-
-		let builder      = build_single_producer(8, factory(), BusySpin)
-			.handle_events_with(processor1);
-		let (mut ep1, b) = builder.event_poller();
-		let (mut ep2, b) = b.and_then().event_poller();
-		let mut producer = b.build();
-
-		// Polling before publication should yield no events.
-		assert_eq!(ep1.poll().err(), Some(Polling::NoEvents));
-		assert_eq!(ep2.poll().err(), Some(Polling::NoEvents));
-
-		// Publish two events.
-		producer.publish(|e| { e.num = 1; });
-		producer.publish(|e| { e.num = 2; });
-		drop(producer);
-
-		let expected = vec![1, 2];
-
-		{// Only first poller sees events.
-			let mut guard_1 = ep1.poll().ok().unwrap();
-			assert_eq!(ep2.poll().err(), Some(Polling::NoEvents));
-			assert_eq!(expected, guard_1.map(|e| e.num).collect::<Vec<_>>());
-		}
-		// Next poll should indicate shutdown to the poller.
-		assert_eq!(ep1.poll().err(), Some(Polling::Shutdown));
-
-		{// Now second poller sees events.
-			let mut guard_2 = ep2.poll().ok().unwrap();
-			assert_eq!(expected, guard_2.map(|e| e.num).collect::<Vec<_>>());
-		}
-
-		let mut result: Vec<i64> = r.iter().collect();
-		result.sort();
-		assert_eq!(expected, result);
-	}
-
-	#[cfg_attr(miri, ignore)]// Miri disabled due to excessive runtime.
-	#[test]
-	fn stress_test() {
-		#[derive(Debug)]
-		struct StressEvent {
-			i: Sequence,
-			a: i64,
-			b: i64,
-			s: String,
-		}
-
-		let (s_seq,   r_seq)   = mpsc::channel();
-		let (s_error, r_error) = mpsc::channel();
-		let num_events         = 250_000;
-		let producers          = 4;
-		let consumers          = 3;
-
-		let mut processors: Vec<_> = (0..consumers).into_iter().map(|pid| {
-			let s_error      = s_error.clone();
-			let s_seq        = s_seq.clone();
-			let mut prev_seq = -1;
-			Some(move |e: &StressEvent, sequence, _| {
-				if e.a != e.i - 5
-				|| e.b != e.i + 7
-				|| e.s != format!("Blackbriar {}", e.i).to_string()
-				|| sequence != prev_seq + 1 {
-					s_error.send(1).expect("Should send.");
-				}
-				else {
-					prev_seq                 = sequence;
-					let sequence_seen_by_pid = sequence*consumers + pid;
-					s_seq.send(sequence_seen_by_pid).expect("Should send.");
-				}
-			})
-		}).collect();
-
-		// Drop unused Senders.
-		drop(s_seq);
-		drop(s_error);
-
-		let factory = || {
-			StressEvent {
-				i: -1,
-				a: -1,
-				b: -1,
-				s: "".to_string()
-			}
-		};
-
-		let producer = build_multi_producer(1 << 16, factory, BusySpin)
-			.handle_events_with(processors[0].take().unwrap())
-			.handle_events_with(processors[1].take().unwrap())
-			.handle_events_with(processors[2].take().unwrap())
-			.build();
-
-		thread::scope(|s| {
-			for _ in 0..producers {
-				let mut producer = producer.clone();
-				s.spawn(move || {
-					for i in 0..num_events {
-						producer.publish(|e| {
-							e.i = i;
-							e.a = i - 5;
-							e.b = i + 7;
-							e.s = format!("Blackbriar {}", i).to_string();
-						});
-					}
-				});
-			}
-			drop(producer); // Drop excess producer not used.
-		});
-
-		let expected_sequence_reads    = consumers*num_events*producers;
-		let errors: Vec<_>             = r_error.iter().collect();
-		let mut seen_sequences: Vec<_> = r_seq.iter().collect();
-
-		assert!(errors.is_empty());
-		assert_eq!(expected_sequence_reads as usize, seen_sequences.len());
-		// Assert that each consumer saw each sequence number.
-		seen_sequences.sort();
-		for seq_seen_by_pid in 0..expected_sequence_reads {
-			assert_eq!(seq_seen_by_pid, seen_sequences[seq_seen_by_pid as usize]);
-		}
-	}
+    use super::*;
+    use producer::MissingFreeSlots;
+    use std::cell::RefCell;
+    use std::collections::HashSet;
+    use std::rc::Rc;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering::Relaxed;
+    use std::sync::{mpsc, Arc};
+    use std::thread;
+    use std::time::Duration;
+
+    #[derive(Debug)]
+    struct Event {
+        num: i64,
+    }
+
+    fn factory() -> impl Fn() -> Event {
+        || Event { num: -1 }
+    }
+
+    #[test]
+    #[should_panic(expected = "Size must be power of 2.")]
+    fn size_not_a_factor_of_2() {
+        build_single_producer(3, || 0, BusySpin);
+    }
+
+    #[test]
+    fn spsc_full_ringbuffer() {
+        let (s, r) = mpsc::channel();
+        let barrier = Arc::new(AtomicBool::new(true));
+        let processor = {
+            let barrier = Arc::clone(&barrier);
+            move |e: &Event, _, _| {
+                while barrier.load(Relaxed) { /* Wait. */ }
+                s.send(e.num).expect("Should be able to send.");
+            }
+        };
+        let mut producer = build_single_producer(4, factory(), BusySpinWithSpinLoopHint)
+            .handle_events_with(processor)
+            .build();
+
+        for i in 0..4 {
+            producer.try_publish(|e| e.num = i).expect("Should publish");
+        }
+        // Now ring buffer is full.
+        assert_eq!(
+            RingBufferFull,
+            producer.try_publish(|e| e.num = 4).err().unwrap()
+        );
+        // And it stays full.
+        assert_eq!(
+            RingBufferFull,
+            producer.try_publish(|e| e.num = 4).err().unwrap()
+        );
+        // Until the processor continues reading events.
+        barrier.store(false, Relaxed);
+        producer.publish(|e| e.num = 4);
+
+        drop(producer);
+        let result: Vec<_> = r.iter().collect();
+        assert_eq!(result, [0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn mpsc_full_ringbuffer() {
+        let (s, r) = mpsc::channel();
+        let barrier = Arc::new(AtomicBool::new(true));
+        let processor = {
+            let barrier = Arc::clone(&barrier);
+            move |e: &Event, _, _| {
+                while barrier.load(Relaxed) { /* Wait. */ }
+                s.send(e.num).expect("Should be able to send.");
+            }
+        };
+        let mut producer1 = build_multi_producer(64, factory(), BusySpinWithSpinLoopHint)
+            .handle_events_with(processor)
+            .build();
+
+        let mut producer2 = producer1.clone();
+
+        for i in 0..64 {
+            producer1
+                .try_publish(|e| e.num = i)
+                .expect("Should publish");
+        }
+
+        // Now ring buffer is full.
+        assert_eq!(
+            RingBufferFull,
+            producer1.try_publish(|e| e.num = 4).err().unwrap()
+        );
+        // And it is full also as seen from second producer.
+        assert_eq!(
+            RingBufferFull,
+            producer2.try_publish(|e| e.num = 4).err().unwrap()
+        );
+        // Until the processor continues reading events.
+        barrier.store(false, Relaxed);
+        producer1.publish(|e| e.num = 64);
+        producer2.publish(|e| e.num = 65);
+
+        drop(producer1);
+        drop(producer2);
+        let result: Vec<_> = r.iter().collect();
+        assert_eq!(result, (0..=65).into_iter().collect::<Vec<i64>>());
+    }
+
+    #[test]
+    fn spsc_insufficient_space_for_batch_publication() {
+        let (s, r) = mpsc::channel();
+        let barrier = Arc::new(AtomicBool::new(true));
+        let processor = {
+            let barrier = Arc::clone(&barrier);
+            move |e: &Event, _, _| {
+                while barrier.load(Relaxed) { /* Wait. */ }
+                s.send(e.num).expect("Should be able to send.");
+            }
+        };
+        let mut producer = build_single_producer(4, factory(), BusySpin)
+            .handle_events_with(processor)
+            .build();
+
+        for i in 0..2 {
+            producer.publish(|e| e.num = i);
+        }
+        assert_eq!(
+            MissingFreeSlots(2),
+            producer.try_batch_publish(4, |_iter| {}).err().unwrap()
+        );
+        assert_eq!(
+            MissingFreeSlots(100),
+            producer.try_batch_publish(102, |_iter| {}).err().unwrap()
+        );
+
+        barrier.store(false, Relaxed);
+        producer
+            .try_batch_publish(2, |iter| {
+                for e in iter {
+                    e.num = 2;
+                }
+            })
+            .expect("Batch publication should now succeed.");
+
+        drop(producer);
+        let result: Vec<_> = r.iter().collect();
+        assert_eq!(result, [0, 1, 2, 2]);
+    }
+
+    #[test]
+    fn mpsc_insufficient_space_for_batch_publication() {
+        let (s, r) = mpsc::channel();
+        let barrier = Arc::new(AtomicBool::new(true));
+        let processor = {
+            let barrier = Arc::clone(&barrier);
+            move |e: &Event, _, _| {
+                while barrier.load(Relaxed) { /* Wait. */ }
+                s.send(e.num).expect("Should be able to send.");
+            }
+        };
+        let mut producer1 = build_multi_producer(64, factory(), BusySpin)
+            .handle_events_with(processor)
+            .build();
+        let mut producer2 = producer1.clone();
+
+        for i in 0..58 {
+            producer1.publish(|e| e.num = i);
+        }
+        assert_eq!(
+            MissingFreeSlots(2),
+            producer1.try_batch_publish(8, |_iter| {}).err().unwrap()
+        );
+        assert_eq!(
+            MissingFreeSlots(100),
+            producer1.try_batch_publish(106, |_iter| {}).err().unwrap()
+        );
+        assert_eq!(
+            MissingFreeSlots(2),
+            producer2.try_batch_publish(8, |_iter| {}).err().unwrap()
+        );
+        assert_eq!(
+            MissingFreeSlots(100),
+            producer2.try_batch_publish(106, |_iter| {}).err().unwrap()
+        );
+
+        barrier.store(false, Relaxed);
+        producer1
+            .try_batch_publish(2, |iter| {
+                for e in iter {
+                    e.num = 2;
+                }
+            })
+            .expect("Batch publication should now succeed.");
+        producer2
+            .try_batch_publish(2, |iter| {
+                for e in iter {
+                    e.num = 3;
+                }
+            })
+            .expect("Batch publication should now succeed.");
+
+        drop(producer1);
+        drop(producer2);
+        let mut result: Vec<_> = r.iter().collect();
+        result.sort();
+        // Initial events published.
+        let mut expected = (0..58).into_iter().collect::<Vec<i64>>();
+        // Now add the two successfull batch publications.
+        expected.push(2);
+        expected.push(2);
+        expected.push(3);
+        expected.push(3);
+        expected.sort();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn spsc_disruptor() {
+        let (s, r) = mpsc::channel();
+        let processor = move |e: &Event, _, _| {
+            s.send(e.num).expect("Should be able to send.");
+        };
+        let mut producer = build_single_producer(8, factory(), BusySpin)
+            .handle_events_with(processor)
+            .build();
+
+        thread::scope(|s| {
+            s.spawn(move || {
+                for i in 0..10 {
+                    producer.publish(|e| e.num = i * i);
+                }
+            });
+        });
+
+        let result: Vec<_> = r.iter().collect();
+        assert_eq!(result, [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn spsc_disruptor_with_pinned_and_named_thread() {
+        let (s, r) = mpsc::channel();
+        let processor = move |e: &Event, _, _| {
+            s.send(e.num).expect("Should be able to send.");
+        };
+        let mut producer = build_single_producer(8, factory(), BusySpin)
+            .pin_at_core(0)
+            .thread_name("my-processor")
+            .handle_events_with(processor)
+            .build();
+
+        thread::scope(|s| {
+            s.spawn(move || {
+                for i in 0..10 {
+                    producer.publish(|e| e.num = i * i);
+                }
+            });
+        });
+
+        let result: Vec<_> = r.iter().collect();
+        assert_eq!(result, [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]);
+    }
+
+    #[test]
+    fn spsc_disruptor_with_batch_publication() {
+        let (s, r) = mpsc::channel();
+        let processor = move |e: &Event, _, _| {
+            s.send(e.num).expect("Should be able to send.");
+        };
+        let mut producer = build_single_producer(8, factory(), BusySpin)
+            .handle_events_with(processor)
+            .build();
+
+        let mut i = 0;
+        for _ in 0..3 {
+            producer.batch_publish(3, |iter| {
+                // We are guaranteed that the iterator will yield three elements:
+                assert_eq!((3, Some(3)), iter.size_hint());
+
+                // Publish.
+                for e in iter {
+                    e.num = i * i;
+                    i += 1;
+                }
+            });
+        }
+        drop(producer);
+
+        let result: Vec<_> = r.iter().collect();
+        assert_eq!(result, [0, 1, 4, 9, 16, 25, 36, 49, 64]);
+    }
+
+    #[test]
+    fn end_of_batch_flag_sequences() {
+        let (s, r) = mpsc::channel();
+        let mut flags = Vec::new();
+        let processor = move |_e: &Event, _seq, end_of_batch| {
+            s.send(end_of_batch).expect("Should be able to send.");
+        };
+        let mut producer = build_single_producer(8, factory(), BusySpin)
+            .handle_events_with(processor)
+            .build();
+
+        for _ in 0..3 {
+            producer.publish(|_| {});
+        }
+        drop(producer);
+
+        flags.extend(r.iter());
+        assert_eq!(flags, vec![false, false, true]);
+    }
+
+    #[test]
+    fn spsc_disruptor_with_zero_batch_publication() {
+        let (s, r) = mpsc::channel();
+        let processor = move |e: &Event, _, _| {
+            s.send(e.num).expect("Should be able to send.");
+        };
+        let mut producer = build_single_producer(8, factory(), BusySpin)
+            .handle_events_with(processor)
+            .build();
+
+        producer.batch_publish(0, |iter| {
+            for e in iter {
+                e.num = 1;
+            }
+        });
+        drop(producer);
+
+        let result: Vec<_> = r.iter().collect();
+        assert_eq!(result, Vec::<i64>::new());
+    }
+
+    #[test]
+    fn spsc_disruptor_with_state() {
+        let (s, r) = mpsc::channel();
+        let initialize_state = || Rc::new(RefCell::new(0));
+        let processor = move |state: &mut Rc<RefCell<i64>>, e: &Event, _, _| {
+            let mut ref_cell = state.borrow_mut();
+            *ref_cell += e.num;
+            s.send(*ref_cell).expect("Should be able to send.");
+        };
+        let mut producer = build_single_producer(8, factory(), BusySpin)
+            .handle_events_and_state_with(processor, initialize_state)
+            .build();
+
+        for i in 0..10 {
+            producer.publish(|e| e.num = i);
+        }
+
+        drop(producer);
+        let result: Vec<_> = r.iter().collect();
+        assert_eq!(result, [0, 1, 3, 6, 10, 15, 21, 28, 36, 45]);
+    }
+
+    #[test]
+    fn pipeline_of_two_spsc_disruptors() {
+        let (s, r) = mpsc::channel();
+        let processor = move |e: &Event, _, _| {
+            s.send(e.num).expect("Should be able to send.");
+        };
+
+        // Last Disruptor.
+        let mut producer = build_single_producer(8, factory(), BusySpin)
+            .handle_events_with(processor)
+            .build();
+        let processor = move |e: &Event, _, _| {
+            producer.publish(|e2| e2.num = e.num);
+        };
+
+        // First Disruptor.
+        let mut producer = build_single_producer(8, factory(), BusySpin)
+            .handle_events_with(processor)
+            .build();
+        for i in 0..10 {
+            producer.publish(|e| e.num = i * i);
+        }
+
+        drop(producer);
+        let result: Vec<_> = r.iter().collect();
+        assert_eq!(result, [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]);
+    }
+
+    #[test]
+    fn multi_publisher_disruptor() {
+        let (s, r) = mpsc::channel();
+        let processor = move |e: &Event, _, _| {
+            s.send(e.num).expect("Should be able to send.");
+        };
+
+        let mut producer1 = build_multi_producer(64, factory(), BusySpinWithSpinLoopHint)
+            .handle_events_with(processor)
+            .build();
+        let mut producer2 = producer1.clone();
+
+        let num_items = 100;
+
+        thread::scope(|s| {
+            s.spawn(move || {
+                for i in 0..num_items / 2 {
+                    producer1.publish(|e| e.num = i);
+                }
+            });
+
+            s.spawn(move || {
+                for i in (num_items / 2)..num_items {
+                    producer2.publish(|e| e.num = i);
+                }
+            });
+        });
+
+        let mut result: Vec<_> = r.iter().collect();
+        result.sort();
+
+        let expected: Vec<i64> = (0..num_items).collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn multi_publisher_disruptor_with_batch_publication() {
+        let (s, r) = mpsc::channel();
+        let processor = move |e: &Event, _, _| {
+            s.send(e.num).expect("Should be able to send.");
+        };
+
+        let mut producer1 = build_multi_producer(64, factory(), BusySpin)
+            .handle_events_with(processor)
+            .build();
+        let mut producer2 = producer1.clone();
+
+        let num_items = 100_i64;
+        let batch_size = 5;
+
+        thread::scope(|s| {
+            s.spawn(move || {
+                for b in 0..(num_items / 2) / batch_size {
+                    producer1.batch_publish(batch_size as usize, |iter| {
+                        for (i, e) in iter.enumerate() {
+                            e.num = batch_size * b + i as i64;
+                        }
+                    });
+                }
+            });
+
+            s.spawn(move || {
+                for i in (num_items / 2)..num_items {
+                    producer2.publish(|e| e.num = i as i64);
+                }
+            });
+        });
+
+        let mut result: Vec<_> = r.iter().collect();
+        result.sort();
+
+        let expected: Vec<i64> = (0..num_items).collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn multi_publisher_wraparound_under_contention() {
+        let (s, r) = mpsc::channel();
+        let processor = move |e: &Event, _, _| {
+            s.send(e.num).expect("Should be able to send.");
+        };
+
+        // Small ring size to force wraparound; consumer should keep up via handler thread.
+        let mut producer1 = build_multi_producer(64, factory(), BusySpin)
+            .handle_events_with(processor)
+            .build();
+        let mut producer2 = producer1.clone();
+
+        let total = 200;
+        thread::scope(|scope| {
+            scope.spawn(move || {
+                for i in 0..(total / 2) {
+                    producer1.publish(|e| e.num = i as i64);
+                }
+            });
+            scope.spawn(move || {
+                for i in (total / 2)..total {
+                    producer2.publish(|e| e.num = i as i64);
+                }
+            });
+        });
+
+        let mut result: Vec<_> = r.iter().collect();
+        result.sort();
+        let expected: Vec<i64> = (0..total).collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn spmc_with_concurrent_consumers() {
+        let (s, r) = mpsc::channel();
+
+        let processor1 = {
+            let s = s.clone();
+            move |e: &Event, _, _| {
+                s.send(e.num + 1).unwrap();
+            }
+        };
+        let processor2 = {
+            let s = s.clone();
+            move |e: &Event, _, _| {
+                s.send(e.num + 2).unwrap();
+            }
+        };
+        let processor3 = {
+            move |e: &Event, _, _| {
+                s.send(e.num + 3).unwrap();
+            }
+        };
+
+        let builder = build_single_producer(8, factory(), BusySpin);
+        let mut producer = builder
+            .handle_events_with(processor1)
+            .handle_events_with(processor2)
+            .handle_events_with(processor3)
+            .build();
+
+        producer.publish(|e| {
+            e.num = 0;
+        });
+        drop(producer);
+
+        let result: HashSet<i64> = r.iter().collect();
+        let expected = HashSet::from([1, 2, 3]);
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn spmc_with_dependent_consumers_and_some_with_state() {
+        let (s, r) = mpsc::channel();
+
+        let processor1 = {
+            let s = s.clone();
+            move |e: &Event, _, _| {
+                s.send(e.num + 0).unwrap();
+            }
+        };
+        let processor2 = {
+            let s = s.clone();
+            move |state: &mut RefCell<i64>, e: &Event, _, _| {
+                *state.borrow_mut() += e.num;
+                s.send(*state.borrow() + 10).unwrap();
+            }
+        };
+        let processor3 = {
+            let s = s.clone();
+            move |e: &Event, _, _| {
+                s.send(e.num + 2).unwrap();
+            }
+        };
+        let processor4 = {
+            let s = s.clone();
+            move |state: &mut RefCell<i64>, e: &Event, _, _| {
+                *state.borrow_mut() += e.num;
+                s.send(*state.borrow() + 20).unwrap();
+            }
+        };
+        let processor5 = {
+            let s = s.clone();
+            move |e: &Event, _, _| {
+                s.send(e.num + 4).unwrap();
+            }
+        };
+        let processor6 = {
+            move |state: &mut RefCell<i64>, e: &Event, _, _| {
+                *state.borrow_mut() += e.num;
+                s.send(*state.borrow() + 30).unwrap();
+            }
+        };
+
+        let builder = build_single_producer(8, factory(), BusySpin);
+
+        let mut producer = builder
+            .handle_events_with(processor1)
+            .handle_events_and_state_with(processor2, || RefCell::new(0))
+            .and_then()
+            .handle_events_with(processor3)
+            .handle_events_and_state_with(processor4, || RefCell::new(0))
+            .and_then()
+            .handle_events_with(processor5)
+            .handle_events_and_state_with(processor6, || RefCell::new(0))
+            .build();
+
+        producer.publish(|e| {
+            e.num = 1;
+        });
+        drop(producer);
+
+        let mut result: Vec<i64> = r.iter().collect();
+        result.sort();
+        assert_eq!(vec![1, 3, 5, 11, 21, 31], result);
+    }
+
+    #[test]
+    fn mpmc_with_dependent_consumers_and_some_with_state() {
+        let (s, r) = mpsc::channel();
+
+        let processor1 = {
+            let s = s.clone();
+            move |e: &Event, _, _| {
+                s.send(e.num + 0).unwrap();
+            }
+        };
+        let processor2 = {
+            let s = s.clone();
+            move |state: &mut RefCell<i64>, e: &Event, _, _| {
+                *state.borrow_mut() += e.num;
+                s.send(*state.borrow() + 10).unwrap();
+            }
+        };
+        let processor3 = {
+            let s = s.clone();
+            move |e: &Event, _, _| {
+                s.send(e.num + 2).unwrap();
+            }
+        };
+        let processor4 = {
+            let s = s.clone();
+            move |state: &mut RefCell<i64>, e: &Event, _, _| {
+                *state.borrow_mut() += e.num;
+                s.send(*state.borrow() + 20).unwrap();
+            }
+        };
+        let processor5 = {
+            let s = s.clone();
+            move |e: &Event, _, _| {
+                s.send(e.num + 4).unwrap();
+            }
+        };
+        let processor6 = {
+            move |state: &mut RefCell<i64>, e: &Event, _, _| {
+                *state.borrow_mut() += e.num;
+                s.send(*state.borrow() + 30).unwrap();
+            }
+        };
+
+        let builder = build_multi_producer(64, factory(), BusySpin);
+        let mut producer1 = builder
+            .handle_events_with(processor1)
+            .handle_events_and_state_with(processor2, || RefCell::new(0))
+            .and_then()
+            .handle_events_with(processor3)
+            .handle_events_and_state_with(processor4, || RefCell::new(0))
+            .and_then()
+            .handle_events_with(processor5)
+            .handle_events_and_state_with(processor6, || RefCell::new(0))
+            .build();
+
+        let mut producer2 = producer1.clone();
+
+        thread::scope(|s| {
+            s.spawn(move || {
+                producer1.publish(|e| e.num = 1);
+            });
+
+            s.spawn(move || {
+                producer2.publish(|e| e.num = 1);
+            });
+        });
+
+        let mut result: Vec<i64> = r.iter().collect();
+        result.sort();
+        assert_eq!(vec![1, 1, 3, 3, 5, 5, 11, 12, 21, 22, 31, 32], result);
+    }
+
+    #[test]
+    fn spmc_with_event_pollers() {
+        let builder = build_single_producer(8, factory(), BusySpin);
+        let (mut ep1, b) = builder.event_poller();
+        let (mut ep2, b) = b.and_then().event_poller();
+        let (mut ep3, b) = b.and_then().event_poller();
+        let mut producer = b.build();
+
+        // Polling before publication should yield no events.
+        assert_eq!(ep1.poll().err(), Some(Polling::NoEvents));
+        assert_eq!(ep2.poll().err(), Some(Polling::NoEvents));
+        assert_eq!(ep3.poll().err(), Some(Polling::NoEvents));
+
+        // Publish two events.
+        producer.publish(|e| {
+            e.num = 1;
+        });
+        producer.publish(|e| {
+            e.num = 2;
+        });
+
+        let expected = vec![1, 2];
+
+        {
+            // Only first poller sees events.
+            let mut guard_1 = ep1.poll().ok().unwrap();
+            assert_eq!(ep2.poll().err(), Some(Polling::NoEvents));
+            assert_eq!(ep3.poll().err(), Some(Polling::NoEvents));
+            assert_eq!(expected, guard_1.map(|e| e.num).collect::<Vec<_>>());
+        }
+
+        {
+            // Now second poller sees events.
+            let mut guard_2 = ep2.poll().ok().unwrap();
+            assert_eq!(ep3.poll().err(), Some(Polling::NoEvents));
+            assert_eq!(expected, guard_2.map(|e| e.num).collect::<Vec<_>>());
+        }
+
+        {
+            // Now third poller sees events.
+            let mut guard_3 = ep3.poll().ok().unwrap();
+            assert_eq!(expected, guard_3.map(|e| e.num).collect::<Vec<_>>());
+        }
+
+        // Dropping the producer should indicate shutdown to all pollers.
+        drop(producer);
+        assert_eq!(ep1.poll().err(), Some(Polling::Shutdown));
+        assert_eq!(ep2.poll().err(), Some(Polling::Shutdown));
+        assert_eq!(ep3.poll().err(), Some(Polling::Shutdown));
+    }
+
+    #[test]
+    fn mpmc_with_event_pollers() {
+        let builder = build_multi_producer(64, factory(), BusySpin);
+        let (mut ep1, b) = builder.event_poller();
+        let (mut ep2, b) = b.and_then().event_poller();
+        let (mut ep3, b) = b.and_then().event_poller();
+        let mut producer1 = b.build();
+        let mut producer2 = producer1.clone();
+
+        // Polling before publication should yield no events.
+        assert_eq!(ep1.poll().err(), Some(Polling::NoEvents));
+        assert_eq!(ep2.poll().err(), Some(Polling::NoEvents));
+        assert_eq!(ep3.poll().err(), Some(Polling::NoEvents));
+
+        // Publish two events.
+        producer1.publish(|e| {
+            e.num = 1;
+        });
+        producer2.publish(|e| {
+            e.num = 2;
+        });
+
+        let expected = HashSet::from([1, 2]);
+
+        {
+            // Only first poller sees events.
+            let mut guard_1 = ep1.poll().ok().unwrap();
+            assert_eq!(ep2.poll().err(), Some(Polling::NoEvents));
+            assert_eq!(ep3.poll().err(), Some(Polling::NoEvents));
+            assert_eq!(expected, guard_1.map(|e| e.num).collect::<HashSet<_>>());
+        }
+
+        {
+            // Now second poller sees events.
+            let mut guard_2 = ep2.poll().ok().unwrap();
+            assert_eq!(ep3.poll().err(), Some(Polling::NoEvents));
+            assert_eq!(expected, guard_2.map(|e| e.num).collect::<HashSet<_>>());
+        }
+
+        {
+            // Now third poller sees events.
+            let mut guard_3 = ep3.poll().ok().unwrap();
+            assert_eq!(expected, guard_3.map(|e| e.num).collect::<HashSet<_>>());
+        }
+
+        // Dropping the producers should indicate shutdown to all pollers.
+        drop(producer1);
+        drop(producer2);
+        assert_eq!(ep1.poll().err(), Some(Polling::Shutdown));
+        assert_eq!(ep2.poll().err(), Some(Polling::Shutdown));
+        assert_eq!(ep3.poll().err(), Some(Polling::Shutdown));
+    }
+
+    #[test]
+    fn spmc_with_mixed_event_pollers_and_processors() {
+        let (s, r) = mpsc::channel();
+        let processor1 = move |e: &Event, _, _| {
+            s.send(e.num).unwrap();
+        };
+
+        let builder = build_single_producer(8, factory(), BusySpin).handle_events_with(processor1);
+        let (mut ep1, b) = builder.event_poller();
+        let (mut ep2, b) = b.and_then().event_poller();
+        let mut producer = b.build();
+
+        // Polling before publication should yield no events.
+        assert_eq!(ep1.poll().err(), Some(Polling::NoEvents));
+        assert_eq!(ep2.poll().err(), Some(Polling::NoEvents));
+
+        // Publish two events.
+        producer.publish(|e| {
+            e.num = 1;
+        });
+        producer.publish(|e| {
+            e.num = 2;
+        });
+        drop(producer);
+
+        let expected = vec![1, 2];
+
+        {
+            // Only first poller sees events.
+            let mut guard_1 = ep1.poll().ok().unwrap();
+            assert_eq!(ep2.poll().err(), Some(Polling::NoEvents));
+            assert_eq!(expected, guard_1.map(|e| e.num).collect::<Vec<_>>());
+        }
+        // Next poll should indicate shutdown to the poller.
+        assert_eq!(ep1.poll().err(), Some(Polling::Shutdown));
+
+        {
+            // Now second poller sees events.
+            let mut guard_2 = ep2.poll().ok().unwrap();
+            assert_eq!(expected, guard_2.map(|e| e.num).collect::<Vec<_>>());
+        }
+
+        let mut result: Vec<i64> = r.iter().collect();
+        result.sort();
+        assert_eq!(expected, result);
+    }
+
+    #[cfg_attr(miri, ignore)] // Miri disabled due to excessive runtime.
+    #[test]
+    fn stress_test() {
+        #[derive(Debug)]
+        struct StressEvent {
+            i: Sequence,
+            a: i64,
+            b: i64,
+            s: String,
+        }
+
+        let (s_seq, r_seq) = mpsc::channel();
+        let (s_error, r_error) = mpsc::channel();
+        let num_events = 250_000;
+        let producers = 4;
+        let consumers = 3;
+
+        let mut processors: Vec<_> = (0..consumers)
+            .into_iter()
+            .map(|pid| {
+                let s_error = s_error.clone();
+                let s_seq = s_seq.clone();
+                let mut prev_seq = -1;
+                Some(move |e: &StressEvent, sequence, _| {
+                    if e.a != e.i - 5
+                        || e.b != e.i + 7
+                        || e.s != format!("Blackbriar {}", e.i).to_string()
+                        || sequence != prev_seq + 1
+                    {
+                        s_error.send(1).expect("Should send.");
+                    } else {
+                        prev_seq = sequence;
+                        let sequence_seen_by_pid = sequence * consumers + pid;
+                        s_seq.send(sequence_seen_by_pid).expect("Should send.");
+                    }
+                })
+            })
+            .collect();
+
+        // Drop unused Senders.
+        drop(s_seq);
+        drop(s_error);
+
+        let factory = || StressEvent {
+            i: -1,
+            a: -1,
+            b: -1,
+            s: "".to_string(),
+        };
+
+        let producer = build_multi_producer(1 << 16, factory, BusySpin)
+            .handle_events_with(processors[0].take().unwrap())
+            .handle_events_with(processors[1].take().unwrap())
+            .handle_events_with(processors[2].take().unwrap())
+            .build();
+
+        thread::scope(|s| {
+            for _ in 0..producers {
+                let mut producer = producer.clone();
+                s.spawn(move || {
+                    for i in 0..num_events {
+                        producer.publish(|e| {
+                            e.i = i;
+                            e.a = i - 5;
+                            e.b = i + 7;
+                            e.s = format!("Blackbriar {}", i).to_string();
+                        });
+                    }
+                });
+            }
+            drop(producer); // Drop excess producer not used.
+        });
+
+        let expected_sequence_reads = consumers * num_events * producers;
+        let errors: Vec<_> = r_error.iter().collect();
+        let mut seen_sequences: Vec<_> = r_seq.iter().collect();
+
+        assert!(errors.is_empty());
+        assert_eq!(expected_sequence_reads as usize, seen_sequences.len());
+        // Assert that each consumer saw each sequence number.
+        seen_sequences.sort();
+        for seq_seen_by_pid in 0..expected_sequence_reads {
+            assert_eq!(seq_seen_by_pid, seen_sequences[seq_seen_by_pid as usize]);
+        }
+    }
+
+    // ---------- New gating-related tests ----------
+    #[test]
+    fn gating_crash_safety_invariant() {
+        const N: i64 = 10;
+        const FLUSH_POINT: i64 = 4;
+
+        let flushed = Arc::new(DependentSequence::new());
+        let (tx, rx) = mpsc::channel();
+
+        let journal = {
+            let flushed = Arc::clone(&flushed);
+            move |_e: &Event, seq: Sequence, _end_of_batch: bool| {
+                if seq <= FLUSH_POINT {
+                    // Simulate fsync only up to FLUSH_POINT; do not advance further yet.
+                    flushed.set(seq);
+                }
+            }
+        };
+
+        let engine = {
+            let tx = tx.clone();
+            move |_e: &Event, seq: Sequence, _| {
+                tx.send(seq).expect("send engine seq");
+            }
+        };
+
+        {
+            let mut producer = build_single_producer(8, factory(), BusySpin)
+                .handle_events_with(journal)
+                .and_then_with_dependents(vec![flushed.clone()])
+                .handle_events_with(engine)
+                .build();
+
+            for i in 0..N {
+                producer.publish(|e| e.num = i);
+            }
+
+            // Engine must be able to process up to the flushed boundary.
+            for expected in 0..=FLUSH_POINT {
+                let got = rx
+                    .recv_timeout(Duration::from_millis(200))
+                    .expect("engine should process flushed range");
+                assert_eq!(got, expected);
+            }
+
+            // No events beyond the flushed boundary should be visible yet.
+            assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+
+            // Allow the engine to proceed and finish.
+            flushed.set(N - 1);
+        } // Drop producer to signal shutdown.
+
+        // Drain remaining events after releasing the gate.
+        let mut last = FLUSH_POINT;
+        for _ in (FLUSH_POINT + 1)..N {
+            last = rx
+                .recv_timeout(Duration::from_millis(200))
+                .expect("engine should drain after gate release");
+        }
+        assert_eq!(last, N - 1);
+    }
+
+    #[test]
+    fn gating_backpressure_prevents_overwrite() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let start_engine = Arc::new(AtomicBool::new(false));
+        let (tx, rx) = mpsc::channel();
+
+        let engine = {
+            let start_engine = Arc::clone(&start_engine);
+            let tx = tx.clone();
+            move |_e: &Event, seq: Sequence, _| {
+                while !start_engine.load(Ordering::Acquire) {
+                    std::thread::yield_now();
+                }
+                tx.send(seq).expect("send engine seq");
+                std::thread::sleep(Duration::from_millis(20)); // Artificial slowness.
+            }
+        };
+
+        let mut producer = build_single_producer(4, factory(), BusySpin)
+            .handle_events_with(|_e: &Event, _seq, _| {}) // journaller fast
+            .and_then()
+            .handle_events_with(engine)
+            .build();
+
+        for i in 0..4 {
+            producer
+                .try_publish(|e| e.num = i)
+                .expect("first batch fits ring");
+        }
+
+        // With the engine blocked, the ring is full and another publish should fail.
+        assert_eq!(
+            producer.try_publish(|e| e.num = 99).unwrap_err(),
+            RingBufferFull
+        );
+
+        // Let the engine run and consume.
+        start_engine.store(true, Ordering::Release);
+        rx.recv_timeout(Duration::from_millis(200))
+            .expect("engine should consume once unblocked");
+
+        // Backpressure should lift after consumption; allow a small window for cursor to advance.
+        let mut published = false;
+        for _ in 0..10 {
+            if producer.try_publish(|e| e.num = 100).is_ok() {
+                published = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(published, "publish after consumer progress");
+    }
+
+    #[test]
+    fn dependent_gate_backpressure_blocks_overwrite() {
+        // External dependent never advances; producer should hit backpressure on small ring.
+        let gate = Arc::new(DependentSequence::new());
+        let (mut poller, builder) = build_single_producer(4, factory(), BusySpin)
+            .handle_events_with(|_e: &Event, _seq, _| {}) // stage 1 fast
+            .and_then_with_dependents(vec![gate.clone()])
+            .event_poller(); // manual consumer at gated stage
+
+        let mut producer = builder.build();
+
+        // Fill the ring.
+        for i in 0..4 {
+            producer
+                .try_publish(|e| e.num = i)
+                .expect("initial fill fits");
+        }
+
+        // Without advancing the gate, further publish should backpressure.
+        assert_eq!(
+            producer.try_publish(|e| e.num = 99).unwrap_err(),
+            RingBufferFull
+        );
+
+        // Advance gate to release space and consume via poller.
+        gate.set(3);
+        let mut drained = 0;
+        for _ in 0..10 {
+            match poller.poll() {
+                Ok(mut guard) => {
+                    for _ in &mut guard {
+                        drained += 1;
+                    }
+                }
+                Err(_) => std::thread::sleep(Duration::from_millis(5)),
+            }
+            if drained >= 4 {
+                break;
+            }
+        }
+        assert_eq!(drained, 4, "poller should consume after gate advances");
+
+        // Backpressure should lift after consumption.
+        assert!(producer.try_publish(|e| e.num = 100).is_ok());
+    }
+
+    #[test]
+    fn gating_min_across_multiple_sequences() {
+        const N: i64 = 6;
+        const ACK_LIMIT: i64 = 2;
+
+        let flushed = Arc::new(DependentSequence::new());
+        let acked = Arc::new(DependentSequence::new());
+        let (tx, rx) = mpsc::channel();
+
+        let journal = {
+            let flushed = Arc::clone(&flushed);
+            let acked = Arc::clone(&acked);
+            move |_e: &Event, seq: Sequence, _end_of_batch: bool| {
+                flushed.set(seq);
+                if seq <= ACK_LIMIT {
+                    // Simulate a lagging replication ACK.
+                    acked.set(seq);
+                }
+            }
+        };
+
+        let engine = {
+            let tx = tx.clone();
+            move |_e: &Event, seq: Sequence, _| {
+                tx.send(seq).expect("send engine seq");
+            }
+        };
+
+        {
+            let mut producer = build_single_producer(8, factory(), BusySpin)
+                .handle_events_with(journal)
+                .and_then_with_dependents(vec![flushed.clone(), acked.clone()])
+                .handle_events_with(engine)
+                .build();
+
+            for i in 0..N {
+                producer.publish(|e| e.num = i);
+            }
+
+            // Engine should only progress to the lagging ACK (min of deps).
+            for expected in 0..=ACK_LIMIT {
+                let got = rx
+                    .recv_timeout(Duration::from_millis(200))
+                    .expect("engine should process up to ack limit");
+                assert_eq!(got, expected);
+            }
+            assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+
+            // Advance ACK to release remaining work.
+            acked.set(N - 1);
+        }
+
+        let mut last = ACK_LIMIT;
+        for _ in (ACK_LIMIT + 1)..N {
+            last = rx
+                .recv_timeout(Duration::from_millis(200))
+                .expect("engine should finish after ack release");
+        }
+        assert_eq!(last, N - 1);
+    }
+
+    #[test]
+    fn gating_min_with_fanout_consumers() {
+        // Two parallel handlers in stage1; stage2 gated on min(cursor_a, cursor_b, gate).
+        const N: i64 = 8;
+
+        let flushed = Arc::new(DependentSequence::new());
+        let (tx_stage2, rx_stage2) = mpsc::channel();
+
+        // Handler A is fast.
+        let handler_a = |_e: &Event, _seq: Sequence, _| { /* fast */ };
+
+        // Handler B is slow/lagging to force min computation to wait.
+        let handler_b = |_e: &Event, seq: Sequence, _| {
+            if seq == 2 {
+                std::thread::sleep(Duration::from_millis(30));
+            }
+        };
+
+        // Stage2 should only advance when both A and B have processed and gate is opened.
+        let stage2 = {
+            let tx = tx_stage2.clone();
+            move |_e: &Event, seq: Sequence, _| {
+                tx.send(seq).expect("stage2 send");
+            }
+        };
+
+        {
+            let mut producer = build_single_producer(8, factory(), BusySpin)
+                .handle_events_with(handler_a)
+                .handle_events_with(handler_b) // fan-out: MC state
+                .and_then_with_dependents(vec![flushed.clone()])
+                .handle_events_with(stage2)
+                .build();
+
+            for i in 0..N {
+                producer.publish(|e| e.num = i);
+                if i >= 0 {
+                    // let gate track producer immediately; barrier min should still wait on handler_b
+                    flushed.set(i);
+                }
+            }
+        } // drop producer to signal shutdown
+
+        // We expect ordered delivery 0..N-1, but only after both cursors have advanced.
+        let mut seen = Vec::new();
+        for _ in 0..N {
+            seen.push(rx_stage2.recv_timeout(Duration::from_millis(200)).unwrap());
+        }
+        assert_eq!(seen, (0..N).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn dependent_sequence_is_cacheline_padded() {
+        let align_seq = std::mem::align_of::<DependentSequence>();
+        let align_pad = std::mem::align_of::<crossbeam_utils::CachePadded<i64>>();
+
+        // Guardrail: we should track CachePadded's alignment (64 on x86_64, 128 on Apple M).
+        assert_eq!(
+            align_seq, align_pad,
+            "DependentSequence alignment {} diverged from CachePadded {}",
+            align_seq, align_pad
+        );
+        assert!(
+            align_seq >= 64 && align_seq.is_power_of_two(),
+            "alignment too small or not power of two: {}",
+            align_seq
+        );
+    }
 }

--- a/src/producer/multi.rs
+++ b/src/producer/multi.rs
@@ -1,458 +1,504 @@
-use std::{process, sync::{atomic::{fence, AtomicI64, AtomicU64, Ordering}, Arc, Mutex}};
+use crate::{
+    barrier::{Barrier, NONE},
+    consumer::Consumer,
+    cursor::Cursor,
+    producer::ProducerBarrier,
+    producer::{Producer, RingBufferFull},
+    ringbuffer::RingBuffer,
+    wait_strategies::{WaitStrategy, WakeupNotifier},
+    Sequence,
+};
 use crossbeam_utils::CachePadded;
-use crate::{barrier::{Barrier, NONE}, consumer::Consumer, producer::ProducerBarrier, ringbuffer::RingBuffer, producer::{Producer, RingBufferFull}, Sequence};
-use crate::cursor::Cursor;
+use std::{
+    process,
+    sync::{
+        atomic::{fence, AtomicI64, AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+};
 
 use super::{MissingFreeSlots, MutBatchIter};
 
 struct SharedProducer {
-	consumers: Vec<Consumer>,
-	counter:   AtomicI64,
+    consumers: Vec<Consumer>,
+    counter: AtomicI64,
 }
 
 /// Producer for publishing to the Disruptor from multiple threads.
 ///
 /// See also [SingleProducer](crate::SingleProducer) for single-threaded publication and
 /// [`Producer`] for how to use a Producer.
-pub struct MultiProducer<E, C> {
-	shutdown_at_sequence:        Arc<CachePadded<AtomicI64>>,
-	ring_buffer:                 Arc<RingBuffer<E>>,
-	shared_producer:             Arc<Mutex<SharedProducer>>,
-	producer_barrier:            Arc<MultiProducerBarrier>,
-	consumer_barrier:            Arc<C>,
-	/// Next sequence number for this MultiProducer to publish.
-	claimed_sequence:            Sequence,
-	/// Highest sequence available for publication because the Consumers are "enough" behind
-	/// to not interfere.
-	sequence_clear_of_consumers: Sequence,
-}
-
-impl<E, C> Producer<E> for MultiProducer<E, C>
+pub struct MultiProducer<E, C, W>
 where
-	C: Barrier
+    C: Barrier,
+    W: WaitStrategy,
 {
-	#[inline]
-	fn try_publish<F>(&mut self, update: F) -> Result<Sequence, RingBufferFull>
-	where
-		F: FnOnce(&mut E)
-	{
-		self.next_sequences(1).map_err(|_| RingBufferFull)?;
-		let sequence = self.apply_update(update);
-		Ok(sequence)
-	}
-
-	#[inline]
-	fn publish<F>(&mut self, update: F)
-	where
-		F: FnOnce(&mut E)
-	{
-		while self.next_sequences(1).is_err() { /* Empty. */ }
-		self.apply_update(update);
-	}
-
-	#[inline]
-	fn try_batch_publish<'a, F>(&'a mut self, n: usize, update: F) -> Result<Sequence, MissingFreeSlots>
-	where
-		E: 'a,
-		F: FnOnce(MutBatchIter<'a, E>),
-	{
-		self.next_sequences(n)?;
-		let sequence = self.apply_updates(n, update);
-		Ok(sequence)
-	}
-
-	#[inline]
-	fn batch_publish<'a, F>(&'a mut self, n: usize, update: F)
-	where
-		E: 'a,
-		F: FnOnce(MutBatchIter<'a, E>)
-	{
-		while self.next_sequences(n).is_err() { /* Empty. */ }
-		self.apply_updates(n, update);
-	}
+    shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
+    ring_buffer: Arc<RingBuffer<E>>,
+    shared_producer: Arc<Mutex<SharedProducer>>,
+    producer_barrier: Arc<MultiProducerBarrier>,
+    consumer_barrier: Arc<C>,
+    notifier: W::Notifier,
+    /// Next sequence number for this MultiProducer to publish.
+    claimed_sequence: Sequence,
+    /// Highest sequence available for publication because the Consumers are "enough" behind
+    /// to not interfere.
+    sequence_clear_of_consumers: Sequence,
 }
 
-impl<E, C> Clone for MultiProducer<E, C> {
-	fn clone(&self) -> Self {
-		let shared = self.shared_producer.lock().unwrap();
-		let count  = shared.counter.fetch_add(1, Ordering::AcqRel);
-
-		// Cloning publishers and calling `mem::forget` on the clones could potentially overflow the
-		// counter. It's very difficult to recover sensibly from such degenerate scenarios so we
-		// just abort when the count becomes very large.
-		if count > i64::MAX/2 {
-			process::abort();
-		}
-
-		let shutdown_at_sequence = Arc::clone(&self.shutdown_at_sequence);
-		let producer_barrier     = Arc::clone(&self.producer_barrier);
-		let shared_producer      = Arc::clone(&self.shared_producer);
-		let consumer_barrier     = Arc::clone(&self.consumer_barrier);
-		let ring_buffer          = Arc::clone(&self.ring_buffer);
-
-		MultiProducer {
-			shutdown_at_sequence,
-			ring_buffer,
-			shared_producer,
-			producer_barrier,
-			consumer_barrier,
-			claimed_sequence: NONE,
-			sequence_clear_of_consumers: 0
-		}
-	}
-}
-
-impl<E, C> Drop for MultiProducer<E, C> {
-	fn drop(&mut self) {
-		let mut shared = self.shared_producer.lock().unwrap();
-		let old_count  = shared.counter.fetch_sub(1, Ordering::AcqRel);
-		if old_count == 1 {
-			// All consumers are waiting to read the next sequence.
-			let sequence = self.producer_barrier.current() + 1;
-			self.shutdown_at_sequence.store(sequence, Ordering::Relaxed);
-			shared.consumers.iter_mut().for_each(|c| c.join());
-		}
-	}
-}
-
-impl<E, C> MultiProducer<E, C>
+impl<E, C, W> Producer<E> for MultiProducer<E, C, W>
 where
-	C: Barrier
+    C: Barrier,
+    W: WaitStrategy,
 {
-	pub(crate) fn new(
-		shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
-		ring_buffer:          Arc<RingBuffer<E>>,
-		producer_barrier:     Arc<MultiProducerBarrier>,
-		consumers:            Vec<Consumer>,
-		consumer_barrier:     C,
-	) -> Self
-	{
-		let shared_producer = Arc::new(
-			Mutex::new(
-				SharedProducer {
-					consumers,
-					counter: AtomicI64::new(1)
-				}
-			)
-		);
-		let consumer_barrier            = Arc::new(consumer_barrier);
-		// Known to be available initially as consumers start at index 0.
-		let sequence_clear_of_consumers = ring_buffer.size() - 1;
-		MultiProducer {
-			shutdown_at_sequence,
-			ring_buffer,
-			shared_producer,
-			producer_barrier,
-			consumer_barrier,
-			claimed_sequence: NONE,
-			sequence_clear_of_consumers
-		}
-	}
+    #[inline]
+    fn try_publish<F>(&mut self, update: F) -> Result<Sequence, RingBufferFull>
+    where
+        F: FnOnce(&mut E),
+    {
+        self.next_sequences(1).map_err(|_| RingBufferFull)?;
+        let sequence = self.apply_update(update);
+        Ok(sequence)
+    }
 
-	#[inline]
-	fn next_sequences(&mut self, n: usize) -> Result<Sequence, MissingFreeSlots> {
-		let n           = n as i64;
-		// We get the last produced sequence number and try and increment it.
-		let mut current = self.producer_barrier.current();
-		let mut n_next  = current + n;
+    #[inline]
+    fn publish<F>(&mut self, update: F)
+    where
+        F: FnOnce(&mut E),
+    {
+        while self.next_sequences(1).is_err() { /* Empty. */ }
+        self.apply_update(update);
+    }
 
-		loop {
-			if self.sequence_clear_of_consumers < n_next {
-				// We have to check where the rear consumer is in case we're about to
-				// publish into the slot currently being read by the slowest consumer.
-				// (Consumer is too far behind the producer to publish next n events).
-				let rear_sequence_read = self.consumer_barrier.get_after(current);
-				let free_slots         = self.ring_buffer.free_slots(current, rear_sequence_read);
-				if free_slots < n {
-					return Err(MissingFreeSlots((n - free_slots) as u64));
-				}
-				fence(Ordering::Acquire);
+    #[inline]
+    fn try_batch_publish<'a, F>(
+        &'a mut self,
+        n: usize,
+        update: F,
+    ) -> Result<Sequence, MissingFreeSlots>
+    where
+        E: 'a,
+        F: FnOnce(MutBatchIter<'a, E>),
+    {
+        self.next_sequences(n)?;
+        let sequence = self.apply_updates(n, update);
+        Ok(sequence)
+    }
 
-				// We now know how far we can continue until we get right behind the slowest consumers'
-				// current position without checking where they actually are.
-				self.sequence_clear_of_consumers = current + free_slots;
-			}
+    #[inline]
+    fn batch_publish<'a, F>(&'a mut self, n: usize, update: F)
+    where
+        E: 'a,
+        F: FnOnce(MutBatchIter<'a, E>),
+    {
+        while self.next_sequences(n).is_err() { /* Empty. */ }
+        self.apply_updates(n, update);
+    }
+}
 
-			match self.producer_barrier.compare_exchange(current, n_next) {
-				Ok(_) => {
-					// The sequence interval `]current; n_next] is now exclusive for this producer.
-					self.claimed_sequence = n_next;
-					break;
-				}
-				Err(new_current) => {
-					current = new_current;
-					n_next  = current + n;
-				}
-			}
-		}
+impl<E, C, W> Clone for MultiProducer<E, C, W>
+where
+    C: Barrier,
+    W: WaitStrategy,
+{
+    fn clone(&self) -> Self {
+        let shared = self.shared_producer.lock().unwrap();
+        let count = shared.counter.fetch_add(1, Ordering::AcqRel);
 
-		Ok(n_next)
-	}
+        // Cloning publishers and calling `mem::forget` on the clones could potentially overflow the
+        // counter. It's very difficult to recover sensibly from such degenerate scenarios so we
+        // just abort when the count becomes very large.
+        if count > i64::MAX / 2 {
+            process::abort();
+        }
 
-	/// Precondition: `sequence` is available for publication.
-	#[inline]
-	fn apply_update<F>(&mut self, update: F) -> Sequence
-	where
-		F: FnOnce(&mut E)
-	{
-		let sequence  = self.claimed_sequence;
-		// SAFETY: Now, we have exclusive access to the event at `sequence` and a producer
-		// can now update the data.
-		let event_ptr = self.ring_buffer.get(sequence);
-		let event     = unsafe { &mut *event_ptr };
-		update(event);
-		// Make publication available by publishing `sequence`.
-		self.producer_barrier.publish(sequence);
-		sequence
-	}
+        let shutdown_at_sequence = Arc::clone(&self.shutdown_at_sequence);
+        let producer_barrier = Arc::clone(&self.producer_barrier);
+        let shared_producer = Arc::clone(&self.shared_producer);
+        let consumer_barrier = Arc::clone(&self.consumer_barrier);
+        let ring_buffer = Arc::clone(&self.ring_buffer);
+        let notifier = self.notifier.clone();
 
-	/// Precondition: `sequence` and previous `n - 1` sequences are available for publication.
-	#[inline]
-	fn apply_updates<'a, F>(&'a mut self, n: usize, updates: F) -> Sequence
-	where
-		E: 'a,
-		F: FnOnce(MutBatchIter<'a, E>)
-	{
-		let n      = n as i64;
-		let upper  = self.claimed_sequence;
-		let lower  = upper - n + 1;
-		// SAFETY: Now, we have exclusive access to the event at `sequence` and a producer
-		// can now update the data.
-		let iter   = MutBatchIter::new(lower, upper, &self.ring_buffer);
-		updates(iter);
-		// Make publications available by publishing all the sequences in the interval [lower; upper].
-		fence(Ordering::Release);
-		self.producer_barrier.publish_range_relaxed(lower, n);
-		upper
-	}
+        MultiProducer {
+            shutdown_at_sequence,
+            ring_buffer,
+            shared_producer,
+            producer_barrier,
+            consumer_barrier,
+            notifier,
+            claimed_sequence: NONE,
+            sequence_clear_of_consumers: 0,
+        }
+    }
+}
+
+impl<E, C, W> Drop for MultiProducer<E, C, W>
+where
+    C: Barrier,
+    W: WaitStrategy,
+{
+    fn drop(&mut self) {
+        let mut shared = self.shared_producer.lock().unwrap();
+        let old_count = shared.counter.fetch_sub(1, Ordering::AcqRel);
+        if old_count == 1 {
+            // All consumers are waiting to read the next sequence.
+            let sequence = self.producer_barrier.current() + 1;
+            self.shutdown_at_sequence.store(sequence, Ordering::Relaxed);
+            shared.consumers.iter_mut().for_each(|c| c.join());
+        }
+    }
+}
+
+impl<E, C, W> MultiProducer<E, C, W>
+where
+    C: Barrier,
+    W: WaitStrategy,
+{
+    pub(crate) fn new(
+        shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
+        ring_buffer: Arc<RingBuffer<E>>,
+        producer_barrier: Arc<MultiProducerBarrier>,
+        consumers: Vec<Consumer>,
+        consumer_barrier: C,
+        notifier: W::Notifier,
+    ) -> Self {
+        let shared_producer = Arc::new(Mutex::new(SharedProducer {
+            consumers,
+            counter: AtomicI64::new(1),
+        }));
+        let consumer_barrier = Arc::new(consumer_barrier);
+        // Known to be available initially as consumers start at index 0.
+        let sequence_clear_of_consumers = ring_buffer.size() - 1;
+        MultiProducer {
+            shutdown_at_sequence,
+            ring_buffer,
+            shared_producer,
+            producer_barrier,
+            consumer_barrier,
+            notifier,
+            claimed_sequence: NONE,
+            sequence_clear_of_consumers,
+        }
+    }
+
+    #[inline]
+    fn next_sequences(&mut self, n: usize) -> Result<Sequence, MissingFreeSlots> {
+        let n = n as i64;
+        // We get the last produced sequence number and try and increment it.
+        let mut current = self.producer_barrier.current();
+        let mut n_next = current + n;
+
+        loop {
+            if self.sequence_clear_of_consumers < n_next {
+                // We have to check where the rear consumer is in case we're about to
+                // publish into the slot currently being read by the slowest consumer.
+                // (Consumer is too far behind the producer to publish next n events).
+                let rear_sequence_read = self.consumer_barrier.get_after(current);
+                let free_slots = self.ring_buffer.free_slots(current, rear_sequence_read);
+                if free_slots < n {
+                    return Err(MissingFreeSlots((n - free_slots) as u64));
+                }
+                fence(Ordering::Acquire);
+
+                // We now know how far we can continue until we get right behind the slowest consumers'
+                // current position without checking where they actually are.
+                self.sequence_clear_of_consumers = current + free_slots;
+            }
+
+            match self.producer_barrier.compare_exchange(current, n_next) {
+                Ok(_) => {
+                    // The sequence interval `]current; n_next] is now exclusive for this producer.
+                    self.claimed_sequence = n_next;
+                    break;
+                }
+                Err(new_current) => {
+                    current = new_current;
+                    n_next = current + n;
+                }
+            }
+        }
+
+        Ok(n_next)
+    }
+
+    /// Precondition: `sequence` is available for publication.
+    #[inline]
+    fn apply_update<F>(&mut self, update: F) -> Sequence
+    where
+        F: FnOnce(&mut E),
+    {
+        let sequence = self.claimed_sequence;
+        // SAFETY: Now, we have exclusive access to the event at `sequence` and a producer
+        // can now update the data.
+        let event_ptr = self.ring_buffer.get(sequence);
+        let event = unsafe { &mut *event_ptr };
+        update(event);
+        // Make publication available by publishing `sequence`.
+        self.producer_barrier.publish(sequence);
+        self.notifier.wake();
+        sequence
+    }
+
+    /// Precondition: `sequence` and previous `n - 1` sequences are available for publication.
+    #[inline]
+    fn apply_updates<'a, F>(&'a mut self, n: usize, updates: F) -> Sequence
+    where
+        E: 'a,
+        F: FnOnce(MutBatchIter<'a, E>),
+    {
+        let n = n as i64;
+        let upper = self.claimed_sequence;
+        let lower = upper - n + 1;
+        // SAFETY: Now, we have exclusive access to the event at `sequence` and a producer
+        // can now update the data.
+        let iter = MutBatchIter::new(lower, upper, &self.ring_buffer);
+        updates(iter);
+        // Make publications available by publishing all the sequences in the interval [lower; upper].
+        fence(Ordering::Release);
+        self.producer_barrier.publish_range_relaxed(lower, n);
+        self.notifier.wake();
+        self.claimed_sequence
+    }
 }
 
 /// Barrier for multiple producers.
 pub struct MultiProducerBarrier {
-	/// Cursor used by producers to claim exclusive sequences per producer.
-	cursor:      Cursor,
-	/// AtomicU64s each track availability of 64 slots.
-	/// Each bit in the AtomicU64 encodes whether the slot was published in an even or odd round.
-	/// This way producers avoid coordinating directly (with the added overhead that would have).
-	/// Note, producers can never "overtake" each other and overwrite the availability of an event
-	/// in the "previous" round as all producers must wait for the consumer furtherst behind (which
-	/// is again blocked by the slowest producer).
-	available:   Box<[AtomicU64]>,
-	index_mask:  usize,
-	index_shift: usize,
+    /// Cursor used by producers to claim exclusive sequences per producer.
+    cursor: Cursor,
+    /// AtomicU64s each track availability of 64 slots.
+    /// Each bit in the AtomicU64 encodes whether the slot was published in an even or odd round.
+    /// This way producers avoid coordinating directly (with the added overhead that would have).
+    /// Note, producers can never "overtake" each other and overwrite the availability of an event
+    /// in the "previous" round as all producers must wait for the consumer furtherst behind (which
+    /// is again blocked by the slowest producer).
+    available: Box<[AtomicU64]>,
+    index_mask: usize,
+    index_shift: usize,
 }
 
 impl MultiProducerBarrier {
-	pub(crate) fn new(size: usize) -> Self {
-		assert!(size >= 64, "Multi Producer Disruptor must have a size of minimum 64 slots.");
+    pub(crate) fn new(size: usize) -> Self {
+        assert!(
+            size >= 64,
+            "Multi Producer Disruptor must have a size of minimum 64 slots."
+        );
 
-		let cursor      = Cursor::new(NONE);
-		let i64_needed  = size/64;
-		// available encodes 1 bit for each slot.
-		// If the bit is 1 it means that the slot was published in the latest odd round
-		// and 0 means latest even round. A ring buffer starts with round 0 (an even round)
-		// so that is why we initialize with all 1's as nothing is published initially.
-		let all_ones    = !0_u64;
-		let available   = (0..i64_needed).map(|_i| { AtomicU64::new(all_ones) }).collect();
-		let index_mask  = size - 1;
-		let index_shift = Self::log2(size);
+        let cursor = Cursor::new(NONE);
+        let i64_needed = size / 64;
+        // available encodes 1 bit for each slot.
+        // If the bit is 1 it means that the slot was published in the latest odd round
+        // and 0 means latest even round. A ring buffer starts with round 0 (an even round)
+        // so that is why we initialize with all 1's as nothing is published initially.
+        let all_ones = !0_u64;
+        let available = (0..i64_needed).map(|_i| AtomicU64::new(all_ones)).collect();
+        let index_mask = size - 1;
+        let index_shift = Self::log2(size);
 
-		Self { cursor, available, index_mask, index_shift }
-	}
+        Self {
+            cursor,
+            available,
+            index_mask,
+            index_shift,
+        }
+    }
 
-	fn log2(i: usize) -> usize {
-		std::mem::size_of::<usize>()*8 - (i.leading_zeros() as usize) - 1
-	}
+    fn log2(i: usize) -> usize {
+        std::mem::size_of::<usize>() * 8 - (i.leading_zeros() as usize) - 1
+    }
 
-	#[inline]
-	fn current(&self) -> Sequence {
-		self.cursor.relaxed_value()
-	}
+    #[inline]
+    fn current(&self) -> Sequence {
+        self.cursor.relaxed_value()
+    }
 
-	#[inline]
-	fn compare_exchange(&self, current: Sequence, next: Sequence) -> Result<i64, i64> {
-		self.cursor.compare_exchange(current, next)
-	}
+    #[inline]
+    fn compare_exchange(&self, current: Sequence, next: Sequence) -> Result<i64, i64> {
+        self.cursor.compare_exchange(current, next)
+    }
 
-	/// Returns the availability index and the bit index of the given sequence number.
-	#[inline]
-	fn calculate_availability_indices(&self, sequence: Sequence) -> (usize, usize) {
-		let slot_index         = self.slot_index(sequence);
-		let availability_index = slot_index >> 6; // == divide by 64.
-		let bit_index          = slot_index - availability_index*64;
-		(availability_index, bit_index)
-	}
+    /// Returns the availability index and the bit index of the given sequence number.
+    #[inline]
+    fn calculate_availability_indices(&self, sequence: Sequence) -> (usize, usize) {
+        let slot_index = self.slot_index(sequence);
+        let availability_index = slot_index >> 6; // == divide by 64.
+        let bit_index = slot_index - availability_index * 64;
+        (availability_index, bit_index)
+    }
 
-	#[inline]
-	fn slot_index(&self, sequence: Sequence) -> usize {
-		sequence as usize & self.index_mask
-	}
+    #[inline]
+    fn slot_index(&self, sequence: Sequence) -> usize {
+        sequence as usize & self.index_mask
+    }
 
-	/// Calculates if we're in an even (0) or odd (1) round.
-	#[inline]
-	fn calculate_availability_flag(&self, sequence: Sequence) -> u64 {
-		let round = (sequence >> self.index_shift) as u64;
-		round & 1
-	}
+    /// Calculates if we're in an even (0) or odd (1) round.
+    #[inline]
+    fn calculate_availability_flag(&self, sequence: Sequence) -> u64 {
+        let round = (sequence >> self.index_shift) as u64;
+        round & 1
+    }
 
-	#[inline]
-	fn availability_at(&self, index: usize) -> &AtomicU64 {
-		// SAFETY: Index is always calculated with `calculate_availability_index` and is therefore within bounds.
-		unsafe { self.available.get_unchecked(index) }
-	}
+    #[inline]
+    fn availability_at(&self, index: usize) -> &AtomicU64 {
+        // SAFETY: Index is always calculated with `calculate_availability_index` and is therefore within bounds.
+        unsafe { self.available.get_unchecked(index) }
+    }
 
-	#[inline]
-	fn publish_range_relaxed(&self, from: Sequence, n: i64) {
-		let (mut availability_index, mut bit_index) = self.calculate_availability_indices(from);
-		let mut flip_mask                           = 0_u64;
-		let mut availability                        = self.availability_at(availability_index);
+    #[inline]
+    fn publish_range_relaxed(&self, from: Sequence, n: i64) {
+        let (mut availability_index, mut bit_index) = self.calculate_availability_indices(from);
+        let mut flip_mask = 0_u64;
+        let mut availability = self.availability_at(availability_index);
 
-		for i in 0..n {
-			// Encode which bits need to be flipped in the next bit field, counting bit_index upwards while < 63.
-			flip_mask |= 1 << bit_index;
+        for i in 0..n {
+            // Encode which bits need to be flipped in the next bit field, counting bit_index upwards while < 63.
+            flip_mask |= 1 << bit_index;
 
-			if bit_index < 63 { // We shift max 63 places.
-				bit_index += 1;
-			}
-			else {
-				// Commit flip mask so far to current bit field.
-				availability.fetch_xor(flip_mask, Ordering::Relaxed);
-				// Load next bit field and reset flip_mask.
-				let next_sequence       = from + i + 1;
-				(availability_index, _) = self.calculate_availability_indices(next_sequence);
-				availability            = self.availability_at(availability_index);
-				bit_index               = 0;
-				flip_mask               = 0;
-			}
-		}
-		// If there's any remaining - commit them to the last bit field.
-		if flip_mask > 0 {
-			availability.fetch_xor(flip_mask, Ordering::Relaxed);
-		}
-	}
+            if bit_index < 63 {
+                // We shift max 63 places.
+                bit_index += 1;
+            } else {
+                // Commit flip mask so far to current bit field.
+                availability.fetch_xor(flip_mask, Ordering::Relaxed);
+                // Load next bit field and reset flip_mask.
+                let next_sequence = from + i + 1;
+                (availability_index, _) = self.calculate_availability_indices(next_sequence);
+                availability = self.availability_at(availability_index);
+                bit_index = 0;
+                flip_mask = 0;
+            }
+        }
+        // If there's any remaining - commit them to the last bit field.
+        if flip_mask > 0 {
+            availability.fetch_xor(flip_mask, Ordering::Relaxed);
+        }
+    }
 
-	#[inline]
-	fn publish_with_ordering(&self, sequence: Sequence, ordering: Ordering) {
-		let (availability_index, bit_index) = self.calculate_availability_indices(sequence);
-		let availability                    = self.availability_at(availability_index);
-		let mask                            = 1 << bit_index;
-		// XOR operation will flip the bit on exactly the bit_index position - encoding that we have
-		// published an event in an even or odd round.
-		availability.fetch_xor(mask, ordering);
-	}
+    #[inline]
+    fn publish_with_ordering(&self, sequence: Sequence, ordering: Ordering) {
+        let (availability_index, bit_index) = self.calculate_availability_indices(sequence);
+        let availability = self.availability_at(availability_index);
+        let mask = 1 << bit_index;
+        // XOR operation will flip the bit on exactly the bit_index position - encoding that we have
+        // published an event in an even or odd round.
+        availability.fetch_xor(mask, ordering);
+    }
 }
 
 impl Barrier for MultiProducerBarrier {
-	#[inline]
-	fn get_after(&self, prev: Sequence) -> Sequence {
-		let mut availability_flag                   = self.calculate_availability_flag(prev);
-		let (mut availability_index, mut bit_index) = self.calculate_availability_indices(prev);
-		let mut availability                        = self.availability_at(availability_index).load(Ordering::Relaxed);
-		// Shift bits to first relevant bit.
-		availability                              >>= bit_index;
-		let mut highest_available                   = prev;
+    #[inline]
+    fn get_after(&self, prev: Sequence) -> Sequence {
+        let mut availability_flag = self.calculate_availability_flag(prev);
+        let (mut availability_index, mut bit_index) = self.calculate_availability_indices(prev);
+        let mut availability = self
+            .availability_at(availability_index)
+            .load(Ordering::Relaxed);
+        // Shift bits to first relevant bit.
+        availability >>= bit_index;
+        let mut highest_available = prev;
 
-		loop {
-			if availability & 1 != availability_flag {
-				return highest_available - 1;
-			}
-			highest_available += 1;
+        loop {
+            if availability & 1 != availability_flag {
+                return highest_available - 1;
+            }
+            highest_available += 1;
 
-			// Prepare for checking the next bit.
-			if bit_index < 63 { // We shift max 63 places.
-				bit_index     += 1;
-				availability >>= 1;
-			}
-			else {
-				// Load next bit field.
-				(availability_index, _) = self.calculate_availability_indices(highest_available);
-				availability            = self.availability_at(availability_index).load(Ordering::Relaxed);
-				bit_index               = 0;
+            // Prepare for checking the next bit.
+            if bit_index < 63 {
+                // We shift max 63 places.
+                bit_index += 1;
+                availability >>= 1;
+            } else {
+                // Load next bit field.
+                (availability_index, _) = self.calculate_availability_indices(highest_available);
+                availability = self
+                    .availability_at(availability_index)
+                    .load(Ordering::Relaxed);
+                bit_index = 0;
 
-				if availability_index == 0 {
-					// If we wrapped then we're now looking for the flipped bit.
-					// (I.e. from odd to even or from even to odd.)
-					availability_flag ^= 1;
-				}
-			}
-		}
-	}
+                if availability_index == 0 {
+                    // If we wrapped then we're now looking for the flipped bit.
+                    // (I.e. from odd to even or from even to odd.)
+                    availability_flag ^= 1;
+                }
+            }
+        }
+    }
 }
 
 impl ProducerBarrier for MultiProducerBarrier {
-	#[inline]
-	fn publish(&self, sequence: Sequence) {
-		self.publish_with_ordering(sequence, Ordering::Release);
-	}
+    #[inline]
+    fn publish(&self, sequence: Sequence) {
+        self.publish_with_ordering(sequence, Ordering::Release);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn log2() {
-		assert_eq!(1, MultiProducerBarrier::log2(2));
-		assert_eq!(1, MultiProducerBarrier::log2(3));
-		assert_eq!(3, MultiProducerBarrier::log2(8));
-		assert_eq!(3, MultiProducerBarrier::log2(9));
-		assert_eq!(3, MultiProducerBarrier::log2(10));
-		assert_eq!(3, MultiProducerBarrier::log2(11));
-	}
+    #[test]
+    fn log2() {
+        assert_eq!(1, MultiProducerBarrier::log2(2));
+        assert_eq!(1, MultiProducerBarrier::log2(3));
+        assert_eq!(3, MultiProducerBarrier::log2(8));
+        assert_eq!(3, MultiProducerBarrier::log2(9));
+        assert_eq!(3, MultiProducerBarrier::log2(10));
+        assert_eq!(3, MultiProducerBarrier::log2(11));
+    }
 
-	#[test]
-	fn initial_available_sequence_number() {
-		let barrier = MultiProducerBarrier::new(64);
+    #[test]
+    fn initial_available_sequence_number() {
+        let barrier = MultiProducerBarrier::new(64);
 
-		assert_eq!(barrier.get_after(0), -1);
-	}
+        assert_eq!(barrier.get_after(0), -1);
+    }
 
-	#[test]
-	fn publication_of_single_event_for_small_barrier() {
-		let barrier = MultiProducerBarrier::new(64);
+    #[test]
+    fn publication_of_single_event_for_small_barrier() {
+        let barrier = MultiProducerBarrier::new(64);
 
-		barrier.publish_range_relaxed(0, 1);
-		// Verify published:
-		assert_eq!(barrier.get_after(0), 0);
-	}
+        barrier.publish_range_relaxed(0, 1);
+        // Verify published:
+        assert_eq!(barrier.get_after(0), 0);
+    }
 
-	#[test]
-	fn publication_of_range_for_small_barrier() {
-		let barrier = MultiProducerBarrier::new(64);
+    #[test]
+    fn publication_of_range_for_small_barrier() {
+        let barrier = MultiProducerBarrier::new(64);
 
-		barrier.publish_range_relaxed(0, 10);
-		// Verify published:
-		assert_eq!(barrier.get_after(0), 9);
-	}
+        barrier.publish_range_relaxed(0, 10);
+        // Verify published:
+        assert_eq!(barrier.get_after(0), 9);
+    }
 
-	#[test]
-	fn publication_of_range_wrapping_ringbuffer_for_small_barrier() {
-		let barrier = MultiProducerBarrier::new(64);
+    #[test]
+    fn publication_of_range_wrapping_ringbuffer_for_small_barrier() {
+        let barrier = MultiProducerBarrier::new(64);
 
-		barrier.publish_range_relaxed(0, 50);
-		// Verify published:
-		assert_eq!(barrier.get_after(0), 49);
+        barrier.publish_range_relaxed(0, 50);
+        // Verify published:
+        assert_eq!(barrier.get_after(0), 49);
 
-		barrier.publish_range_relaxed(50, 50);
-		// Verify published:
-		assert_eq!(barrier.get_after(49), 99);
-	}
+        barrier.publish_range_relaxed(50, 50);
+        // Verify published:
+        assert_eq!(barrier.get_after(49), 99);
+    }
 
-	#[test]
-	fn publication_of_range_wrapping_ringbuffer_for_barrier() {
-		let barrier = MultiProducerBarrier::new(128);
+    #[test]
+    fn publication_of_range_wrapping_ringbuffer_for_barrier() {
+        let barrier = MultiProducerBarrier::new(128);
 
-		barrier.publish_range_relaxed(0, 100);
-		// Verify published:
-		assert_eq!(barrier.get_after(0), 99);
-		// Verify not published:
+        barrier.publish_range_relaxed(0, 100);
+        // Verify published:
+        assert_eq!(barrier.get_after(0), 99);
+        // Verify not published:
 
-		barrier.publish_range_relaxed(100, 100);
-		// Verify published:
-		assert_eq!(barrier.get_after(99), 199);
+        barrier.publish_range_relaxed(100, 100);
+        // Verify published:
+        assert_eq!(barrier.get_after(99), 199);
 
-		barrier.publish_range_relaxed(200, 100);
-		// Verify published:
-		assert_eq!(barrier.get_after(199), 299);
-	}
+        barrier.publish_range_relaxed(200, 100);
+        // Verify published:
+        assert_eq!(barrier.get_after(199), 299);
+    }
 }

--- a/src/producer/single.rs
+++ b/src/producer/single.rs
@@ -1,193 +1,221 @@
-use std::sync::atomic::{fence, Ordering};
-use crate::{barrier::{Barrier, NONE}, cursor::Cursor, producer::ProducerBarrier};
-use crossbeam_utils::CachePadded;
-use crate::{consumer::Consumer, ringbuffer::RingBuffer, Sequence};
 use super::*;
+use crate::{
+    barrier::{Barrier, NONE},
+    consumer::Consumer,
+    cursor::Cursor,
+    producer::ProducerBarrier,
+    ringbuffer::RingBuffer,
+    wait_strategies::{WaitStrategy, WakeupNotifier},
+    Sequence,
+};
+use crossbeam_utils::CachePadded;
+use std::sync::atomic::{fence, Ordering};
 
 /// Producer for publishing to the Disruptor from a single thread.
 ///
 /// See also [MultiProducer](crate::MultiProducer) for multi-threaded publication and
 /// [`Producer`] for how to use a Producer.
-pub struct SingleProducer<E, C> {
-	shutdown_at_sequence:        Arc<CachePadded<AtomicI64>>,
-	ring_buffer:                 Arc<RingBuffer<E>>,
-	producer_barrier:            Arc<SingleProducerBarrier>,
-	consumers:                   Vec<Consumer>,
-	consumer_barrier:            C,
-	/// Next sequence to be published.
-	sequence:                    Sequence,
-	/// Highest sequence available for publication because the Consumers are "enough" behind
-	/// to not interfere.
-	sequence_clear_of_consumers: Sequence,
+pub struct SingleProducer<E, C, W>
+where
+    C: Barrier,
+    W: WaitStrategy,
+{
+    shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
+    ring_buffer: Arc<RingBuffer<E>>,
+    producer_barrier: Arc<SingleProducerBarrier>,
+    consumers: Vec<Consumer>,
+    consumer_barrier: C,
+    notifier: W::Notifier,
+    /// Next sequence to be published.
+    sequence: Sequence,
+    /// Highest sequence available for publication because the Consumers are "enough" behind
+    /// to not interfere.
+    sequence_clear_of_consumers: Sequence,
 }
 
-impl<E, C> Producer<E> for SingleProducer<E, C>
+impl<E, C, W> Producer<E> for SingleProducer<E, C, W>
 where
-	C: Barrier
+    C: Barrier,
+    W: WaitStrategy,
 {
-	#[inline]
-	fn try_publish<F>(&mut self, update: F) -> Result<Sequence, RingBufferFull>
-	where
-		F: FnOnce(&mut E)
-	{
-		self.next_sequences(1).map_err(|_| RingBufferFull)?;
-		let sequence = self.apply_update(update);
-		Ok(sequence)
-	}
+    #[inline]
+    fn try_publish<F>(&mut self, update: F) -> Result<Sequence, RingBufferFull>
+    where
+        F: FnOnce(&mut E),
+    {
+        self.next_sequences(1).map_err(|_| RingBufferFull)?;
+        let sequence = self.apply_update(update);
+        Ok(sequence)
+    }
 
-	#[inline]
-	fn publish<F>(&mut self, update: F)
-	where
-		F: FnOnce(&mut E)
-	{
-		while self.next_sequences(1).is_err() { /* Empty. */ }
-		self.apply_update(update);
-	}
+    #[inline]
+    fn publish<F>(&mut self, update: F)
+    where
+        F: FnOnce(&mut E),
+    {
+        while self.next_sequences(1).is_err() { /* Empty. */ }
+        self.apply_update(update);
+    }
 
-	#[inline]
-	fn try_batch_publish<'a, F>(&'a mut self, n: usize, update: F) -> Result<Sequence, MissingFreeSlots>
-	where
-		E: 'a,
-		F: FnOnce(MutBatchIter<'a, E>)
-	{
-		self.next_sequences(n)?;
-		let sequence = self.apply_updates(n, update);
-		Ok(sequence)
-	}
+    #[inline]
+    fn try_batch_publish<'a, F>(
+        &'a mut self,
+        n: usize,
+        update: F,
+    ) -> Result<Sequence, MissingFreeSlots>
+    where
+        E: 'a,
+        F: FnOnce(MutBatchIter<'a, E>),
+    {
+        self.next_sequences(n)?;
+        let sequence = self.apply_updates(n, update);
+        Ok(sequence)
+    }
 
-	#[inline]
-	fn batch_publish<'a, F>(&'a mut self, n: usize, update: F)
-	where
-		E: 'a,
-		F: FnOnce(MutBatchIter<'a, E>)
-	{
-		while self.next_sequences(n).is_err() { /* Empty. */ }
-		self.apply_updates(n, update);
-	}
+    #[inline]
+    fn batch_publish<'a, F>(&'a mut self, n: usize, update: F)
+    where
+        E: 'a,
+        F: FnOnce(MutBatchIter<'a, E>),
+    {
+        while self.next_sequences(n).is_err() { /* Empty. */ }
+        self.apply_updates(n, update);
+    }
 }
 
-impl<E, C> SingleProducer<E, C>
+impl<E, C, W> SingleProducer<E, C, W>
 where
-	C: Barrier
+    C: Barrier,
+    W: WaitStrategy,
 {
-	pub(crate) fn new(
-		shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
-		ring_buffer:          Arc<RingBuffer<E>>,
-		producer_barrier:     Arc<SingleProducerBarrier>,
-		consumers:            Vec<Consumer>,
-		consumer_barrier:     C,
-	) -> Self
-	{
-		let sequence_clear_of_consumers = ring_buffer.size() - 1;
-		Self {
-			shutdown_at_sequence,
-			ring_buffer,
-			producer_barrier,
-			consumers,
-			consumer_barrier,
-			sequence: 0,
-			sequence_clear_of_consumers,
-		}
-	}
+    pub(crate) fn new(
+        shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
+        ring_buffer: Arc<RingBuffer<E>>,
+        producer_barrier: Arc<SingleProducerBarrier>,
+        consumers: Vec<Consumer>,
+        consumer_barrier: C,
+        notifier: W::Notifier,
+    ) -> Self {
+        let sequence_clear_of_consumers = ring_buffer.size() - 1;
+        Self {
+            shutdown_at_sequence,
+            ring_buffer,
+            producer_barrier,
+            consumers,
+            consumer_barrier,
+            notifier,
+            sequence: 0,
+            sequence_clear_of_consumers,
+        }
+    }
 
-	#[inline]
-	fn next_sequences(&mut self, n: usize) -> Result<Sequence, MissingFreeSlots> {
-		let n      = n as i64;
-		let n_next = self.sequence - 1 + n;
+    #[inline]
+    fn next_sequences(&mut self, n: usize) -> Result<Sequence, MissingFreeSlots> {
+        let n = n as i64;
+        let n_next = self.sequence - 1 + n;
 
-		if self.sequence_clear_of_consumers < n_next {
-			// We have to check where the consumers are in case we're about to overwrite a slot
-			// which is still being read.
-			// (The slowest consumer is too far behind the producer to publish next n events).
-			let last_published     = self.sequence - 1;
-			let rear_sequence_read = self.consumer_barrier.get_after(last_published);
-			let free_slots         = self.ring_buffer.free_slots(last_published, rear_sequence_read);
-			if free_slots < n {
-				return Err(MissingFreeSlots((n - free_slots) as u64));
-			}
-			fence(Ordering::Acquire);
+        if self.sequence_clear_of_consumers < n_next {
+            // We have to check where the consumers are in case we're about to overwrite a slot
+            // which is still being read.
+            // (The slowest consumer is too far behind the producer to publish next n events).
+            let last_published = self.sequence - 1;
+            let rear_sequence_read = self.consumer_barrier.get_after(last_published);
+            let free_slots = self
+                .ring_buffer
+                .free_slots(last_published, rear_sequence_read);
+            if free_slots < n {
+                return Err(MissingFreeSlots((n - free_slots) as u64));
+            }
+            fence(Ordering::Acquire);
 
-			// We can now continue until we get right behind the slowest consumer's current
-			// position without checking where it actually is.
-			self.sequence_clear_of_consumers = last_published + free_slots;
-		}
+            // We can now continue until we get right behind the slowest consumer's current
+            // position without checking where it actually is.
+            self.sequence_clear_of_consumers = last_published + free_slots;
+        }
 
-		Ok(n_next)
-	}
+        Ok(n_next)
+    }
 
-	/// Precondition: `sequence` is available for publication.
-	#[inline]
-	fn apply_update<F>(&mut self, update: F) -> Sequence
-	where
-		F: FnOnce(&mut E)
-	{
-		let sequence  = self.sequence;
-		// SAFETY: Now, we have exclusive access to the event at `sequence` and a producer
-		// can now update the data.
-		let event_ptr = self.ring_buffer.get(sequence);
-		let event     = unsafe { &mut *event_ptr };
-		update(event);
-		// Publish by publishing `sequence`.
-		self.producer_barrier.publish(sequence);
-		// Update sequence that will be published the next time.
-		self.sequence += 1;
-		sequence
-	}
+    /// Precondition: `sequence` is available for publication.
+    #[inline]
+    fn apply_update<F>(&mut self, update: F) -> Sequence
+    where
+        F: FnOnce(&mut E),
+    {
+        let sequence = self.sequence;
+        // SAFETY: Now, we have exclusive access to the event at `sequence` and a producer
+        // can now update the data.
+        let event_ptr = self.ring_buffer.get(sequence);
+        let event = unsafe { &mut *event_ptr };
+        update(event);
+        // Publish by publishing `sequence`.
+        self.producer_barrier.publish(sequence);
+        self.notifier.wake();
+        // Update sequence that will be published the next time.
+        self.sequence += 1;
+        sequence
+    }
 
-	/// Precondition: `sequence` and next `n - 1` sequences are available for publication.
-	#[inline]
-	fn apply_updates<'a, F>(&'a mut self, n: usize, updates: F) -> Sequence
-	where
-		E: 'a,
-		F: FnOnce(MutBatchIter<'a, E>)
-	{
-		let n     = n as i64;
-		let lower = self.sequence;
-		let upper = lower + n - 1;
-		// SAFETY: Now, we have exclusive access to the events between `lower` and `upper` and
-		// a producer can update the data.
-		let iter  = MutBatchIter::new(lower, upper, &self.ring_buffer);
-		updates(iter);
-		// Publish batch by publishing `upper`.
-		self.producer_barrier.publish(upper);
-		// Update sequence that will be published the next time.
-		self.sequence += n;
-		upper
-	}
+    /// Precondition: `sequence` and next `n - 1` sequences are available for publication.
+    #[inline]
+    fn apply_updates<'a, F>(&'a mut self, n: usize, updates: F) -> Sequence
+    where
+        E: 'a,
+        F: FnOnce(MutBatchIter<'a, E>),
+    {
+        let n = n as i64;
+        let lower = self.sequence;
+        let upper = lower + n - 1;
+        // SAFETY: Now, we have exclusive access to the events between `lower` and `upper` and
+        // a producer can update the data.
+        let iter = MutBatchIter::new(lower, upper, &self.ring_buffer);
+        updates(iter);
+        // Publish batch by publishing `upper`.
+        self.producer_barrier.publish(upper);
+        self.notifier.wake();
+        // Update sequence that will be published the next time.
+        self.sequence += n;
+        upper
+    }
 }
 
 /// Stops the processor thread and drops the Disruptor, the processor thread and the [Producer].
-impl<E, C> Drop for SingleProducer<E, C> {
-	fn drop(&mut self) {
-		self.shutdown_at_sequence.store(self.sequence, Ordering::Relaxed);
-		self.consumers.iter_mut().for_each(|c| c.join());
-	}
+impl<E, C, W> Drop for SingleProducer<E, C, W>
+where
+    C: Barrier,
+    W: WaitStrategy,
+{
+    fn drop(&mut self) {
+        self.shutdown_at_sequence
+            .store(self.sequence, Ordering::Relaxed);
+        self.consumers.iter_mut().for_each(|c| c.join());
+    }
 }
 
 /// Barrier for a single producer.
 pub struct SingleProducerBarrier {
-	cursor: Cursor
+    cursor: Cursor,
 }
 
 impl SingleProducerBarrier {
-	pub(crate) fn new() -> Self {
-		Self {
-			cursor: Cursor::new(NONE)
-		}
-	}
+    pub(crate) fn new() -> Self {
+        Self {
+            cursor: Cursor::new(NONE),
+        }
+    }
 }
 
 impl Barrier for SingleProducerBarrier {
-	/// Gets the `Sequence` of the last published event.
-	#[inline]
-	fn get_after(&self, _prev: Sequence) -> Sequence {
-		self.cursor.relaxed_value()
-	}
+    /// Gets the `Sequence` of the last published event.
+    #[inline]
+    fn get_after(&self, _prev: Sequence) -> Sequence {
+        self.cursor.relaxed_value()
+    }
 }
 
 impl ProducerBarrier for SingleProducerBarrier {
-	#[inline]
-	fn publish(&self, sequence: Sequence) {
-		self.cursor.store(sequence);
-	}
+    #[inline]
+    fn publish(&self, sequence: Sequence) {
+        self.cursor.store(sequence);
+    }
 }

--- a/src/ringbuffer.rs
+++ b/src/ringbuffer.rs
@@ -6,93 +6,94 @@ unsafe impl<E> Sync for RingBuffer<E> {}
 
 #[doc(hidden)]
 pub struct RingBuffer<E> {
-	slots:      Box<[UnsafeCell<E>]>,
-	index_mask: i64,
+    slots: Box<[UnsafeCell<E>]>,
+    index_mask: i64,
 }
 
-impl <E> RingBuffer<E> {
-	pub(crate) fn new<F>(size: usize, mut event_factory: F)
-	-> Self
-	where
-		F: FnMut() -> E
-	{
-		if !size.is_power_of_two() { panic!("Size must be power of 2.") }
+impl<E> RingBuffer<E> {
+    pub(crate) fn new<F>(size: usize, mut event_factory: F) -> Self
+    where
+        F: FnMut() -> E,
+    {
+        if !size.is_power_of_two() {
+            panic!("Size must be power of 2.")
+        }
 
-		let slots: Box<[UnsafeCell<E>]> = (0..size)
-			.map(|_i| UnsafeCell::new(event_factory()) )
-			.collect();
-		let index_mask = (size - 1) as i64;
+        let slots: Box<[UnsafeCell<E>]> = (0..size)
+            .map(|_i| UnsafeCell::new(event_factory()))
+            .collect();
+        let index_mask = (size - 1) as i64;
 
-		RingBuffer {
-			slots,
-			index_mask,
-		}
-	}
+        RingBuffer { slots, index_mask }
+    }
 
-	#[inline]
-	fn wrap_point(&self, sequence: Sequence) -> Sequence {
-		sequence - self.size()
-	}
+    #[inline]
+    fn wrap_point(&self, sequence: Sequence) -> Sequence {
+        sequence - self.size()
+    }
 
-	#[inline]
-	pub(crate) fn free_slots(&self, producer: Sequence, highest_read_by_consumers: Sequence) -> i64 {
-		let wrap_point = self.wrap_point(producer);
-		highest_read_by_consumers - wrap_point
-	}
+    #[inline]
+    pub(crate) fn free_slots(
+        &self,
+        producer: Sequence,
+        highest_read_by_consumers: Sequence,
+    ) -> i64 {
+        let wrap_point = self.wrap_point(producer);
+        highest_read_by_consumers - wrap_point
+    }
 
-	/// Callers must ensure that only a single mutable reference or multiple immutable references
-	/// exist at any point in time.
-	#[inline]
-	pub(crate) fn get(&self, sequence: Sequence) -> *mut E {
-		let index = (sequence & self.index_mask) as usize;
-		// SAFETY: Index is within bounds - guaranteed by invariant and index mask.
-		let slot  = unsafe { self.slots.get_unchecked(index) };
-		slot.get()
-	}
+    /// Callers must ensure that only a single mutable reference or multiple immutable references
+    /// exist at any point in time.
+    #[inline]
+    pub(crate) fn get(&self, sequence: Sequence) -> *mut E {
+        let index = (sequence & self.index_mask) as usize;
+        // SAFETY: Index is within bounds - guaranteed by invariant and index mask.
+        let slot = unsafe { self.slots.get_unchecked(index) };
+        slot.get()
+    }
 
-	#[inline]
-	pub(crate) fn size(&self) -> i64 {
-		self.slots.len() as i64
-	}
+    #[inline]
+    pub(crate) fn size(&self) -> i64 {
+        self.slots.len() as i64
+    }
 }
-
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn free_slots() {
-		let ring_buffer = RingBuffer::new(8, || { 0 });
+    #[test]
+    fn free_slots() {
+        let ring_buffer = RingBuffer::new(8, || 0);
 
-		// Round 1:
-		// Publisher has just published 7 and consumer has read 0.
-		assert_eq!(1, ring_buffer.free_slots(7, 0));
-		// Consumer had read 0 and the publisher has just published 8.
-		assert_eq!(0, ring_buffer.free_slots(8, 0));
-		// Producer has published 0 and comsumer read 0.
-		assert_eq!(8, ring_buffer.free_slots(0, 0));
-		// Publisher has just published 3 and consumer is (still) reading 0.
-		assert_eq!(4, ring_buffer.free_slots(3, -1));
-		// Publisher has just published 7 and consumer is (still) reading 0.
-		assert_eq!(0, ring_buffer.free_slots(7, -1));
-		// Publisher has just published 7 and consumer has read 0.
-		assert_eq!(1, ring_buffer.free_slots(7, 0));
-		// Publisher has just released 5 and consumer has read 2.
-		assert_eq!(5, ring_buffer.free_slots(5, 2));
-		// Publisher has just released 5 and consumer has read 3.
-		assert_eq!(6, ring_buffer.free_slots(5, 3));
-		// Publisher has just released 5 and consumer has read 4.
-		assert_eq!(7, ring_buffer.free_slots(5, 4));
-		// Publisher has just released 5 and consumer has read 5.
-		assert_eq!(8, ring_buffer.free_slots(5, 5));
+        // Round 1:
+        // Publisher has just published 7 and consumer has read 0.
+        assert_eq!(1, ring_buffer.free_slots(7, 0));
+        // Consumer had read 0 and the publisher has just published 8.
+        assert_eq!(0, ring_buffer.free_slots(8, 0));
+        // Producer has published 0 and comsumer read 0.
+        assert_eq!(8, ring_buffer.free_slots(0, 0));
+        // Publisher has just published 3 and consumer is (still) reading 0.
+        assert_eq!(4, ring_buffer.free_slots(3, -1));
+        // Publisher has just published 7 and consumer is (still) reading 0.
+        assert_eq!(0, ring_buffer.free_slots(7, -1));
+        // Publisher has just published 7 and consumer has read 0.
+        assert_eq!(1, ring_buffer.free_slots(7, 0));
+        // Publisher has just released 5 and consumer has read 2.
+        assert_eq!(5, ring_buffer.free_slots(5, 2));
+        // Publisher has just released 5 and consumer has read 3.
+        assert_eq!(6, ring_buffer.free_slots(5, 3));
+        // Publisher has just released 5 and consumer has read 4.
+        assert_eq!(7, ring_buffer.free_slots(5, 4));
+        // Publisher has just released 5 and consumer has read 5.
+        assert_eq!(8, ring_buffer.free_slots(5, 5));
 
-		// Round 2:
-		// Publisher has just published 11 and consumer has read 9.
-		assert_eq!(6, ring_buffer.free_slots(11, 9));
-		// Publisher has just published 12 and consumer has read 12.
-		assert_eq!(8, ring_buffer.free_slots(12, 12));
-		// Consumer has read 7 and the publisher has just published 15.
-		assert_eq!(0, ring_buffer.free_slots(15, 7));
-	}
+        // Round 2:
+        // Publisher has just published 11 and consumer has read 9.
+        assert_eq!(6, ring_buffer.free_slots(11, 9));
+        // Publisher has just published 12 and consumer has read 12.
+        assert_eq!(8, ring_buffer.free_slots(12, 12));
+        // Consumer has read 7 and the publisher has just published 15.
+        assert_eq!(0, ring_buffer.free_slots(15, 7));
+    }
 }

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1,0 +1,43 @@
+use crossbeam_utils::CachePadded;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+/// A sequence that can be advanced by external actors (e.g. fsync flush markers).
+///
+/// Defaults to `-1`, matching the initial cursor used internally so a gated stage
+/// is blocked until explicitly advanced. Cache-line padded to reduce false sharing.
+#[repr(align(64))]
+pub struct DependentSequence(CachePadded<AtomicI64>);
+
+impl DependentSequence {
+    /// Create a new sequence initialized to `-1`.
+    pub fn new() -> Self {
+        Self::with_value(-1)
+    }
+
+    /// Create a sequence with the given initial value (power user escape hatch).
+    pub fn with_value(v: i64) -> Self {
+        Self(CachePadded::new(AtomicI64::new(v)))
+    }
+
+    /// Load the current value with `Acquire` ordering.
+    pub fn get(&self) -> i64 {
+        self.0.load(Ordering::Acquire)
+    }
+
+    /// Store a new value with `Release` ordering.
+    pub fn set(&self, v: i64) {
+        self.0.store(v, Ordering::Release);
+    }
+
+    /// Compare and set the value with `AcqRel`/`Acquire` ordering.
+    pub fn compare_and_set(&self, current: i64, new: i64) -> Result<i64, i64> {
+        self.0
+            .compare_exchange(current, new, Ordering::AcqRel, Ordering::Acquire)
+    }
+}
+
+impl Default for DependentSequence {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/wait_strategies.rs
+++ b/src/wait_strategies.rs
@@ -2,38 +2,337 @@
 //!
 //! The lowest latency possible is the [`BusySpin`] strategy.
 //!
-//! To "waist" less CPU time and power, use one of the other strategies which have higher latency.
+//! To "waste" less CPU time and power, use one of the other strategies which have higher latency.
 
-use std::hint;
+use std::{
+    hint,
+    sync::atomic::{fence, AtomicI64, Ordering},
+    thread,
+};
 
-use crate::Sequence;
+use crate::{barrier::Barrier, Sequence};
+use crossbeam_utils::CachePadded;
 
-/// Wait strategies are used by consumers when no new events are ready on the ring buffer.
-pub trait WaitStrategy: Copy + Send {
-	/// The wait strategy will wait for the sequence id being available.
-	fn wait_for(&self, sequence: Sequence);
+/// Error/alert conditions a waiter can encounter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitError {
+    /// The disruptor is shutting down; consumer should stop.
+    Shutdown,
+    /// A wait timed out without progress.
+    Timeout,
+    /// The wait was interrupted (e.g. by a spurious wakeup or external signal).
+    Interrupted,
+}
+
+/// Outcome of waiting for availability.
+pub enum WaitOutcome {
+    /// Highest contiguous sequence available (inclusive).
+    Available {
+        /// Highest available sequence (inclusive).
+        upper: Sequence,
+    },
+    /// The disruptor is shutting down.
+    Shutdown,
+    /// The wait timed out without progress.
+    Timeout,
+}
+
+/// Handle for nudging blocked waiters after publication.
+pub trait WakeupNotifier: Send + Sync {
+    /// Hint waiters that new data may be available.
+    fn wake(&self);
+}
+
+/// No-op wakeup notifier for spin/yield strategies.
+#[derive(Default, Clone)]
+pub struct NoopWakeupNotifier;
+
+impl WakeupNotifier for NoopWakeupNotifier {
+    #[inline]
+    fn wake(&self) {}
+}
+
+/// Public wait strategy; cloneable so producers can hold a copy for signaling.
+pub trait WaitStrategy: Send + Sync + Clone + 'static {
+    /// Per-consumer waiter type that holds any mutable state.
+    type Waiter: Waiter;
+    /// Handle type used by producers to wake blocked waiters.
+    type Notifier: WakeupNotifier + Clone + Send + Sync + 'static;
+
+    /// Create a new waiter instance for a consumer thread.
+    fn new_waiter(&self) -> Self::Waiter;
+
+    /// Called during build to hand producers a wakeup handle.
+    fn notifier(&self) -> Self::Notifier;
+}
+
+/// Per-consumer stateful waiter; owns spin/backoff/park bookkeeping.
+pub trait Waiter: Send {
+    /// Return highest contiguous available ≥ requested, or a terminal/alert condition.
+    ///
+    /// Implementations must issue an `Acquire` fence before returning `Available`.
+    fn wait_for(
+        &mut self,
+        requested: Sequence,
+        barrier: &impl Barrier,
+        shutdown: &CachePadded<AtomicI64>,
+    ) -> WaitOutcome;
 }
 
 /// Busy spin wait strategy. Lowest possible latency.
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy, Default)]
 pub struct BusySpin;
 
 impl WaitStrategy for BusySpin {
-	#[inline]
-	fn wait_for(&self, _sequence: Sequence) {
-		// Do nothing, true busy spin.
-	}
+    type Waiter = BusySpinWaiter;
+    type Notifier = NoopWakeupNotifier;
+
+    #[inline]
+    fn new_waiter(&self) -> Self::Waiter {
+        BusySpinWaiter
+    }
+
+    #[inline]
+    fn notifier(&self) -> Self::Notifier {
+        NoopWakeupNotifier
+    }
+}
+
+/// State holder for [`BusySpin`] wait strategy.
+pub struct BusySpinWaiter;
+
+impl Waiter for BusySpinWaiter {
+    #[inline]
+    fn wait_for(
+        &mut self,
+        requested: Sequence,
+        barrier: &impl Barrier,
+        shutdown: &CachePadded<AtomicI64>,
+    ) -> WaitOutcome {
+        loop {
+            if shutdown.load(Ordering::Relaxed) == requested {
+                return WaitOutcome::Shutdown;
+            }
+
+            let available = barrier.get_after(requested);
+            if available >= requested {
+                fence(Ordering::Acquire);
+                return WaitOutcome::Available { upper: available };
+            }
+        }
+    }
 }
 
 /// Busy spin wait strategy with spin loop hint which enables the processor to optimize its behavior
 /// by e.g. saving power os switching hyper threads. Obviously, this can induce latency.
 ///
 /// See also [`BusySpin`].
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy, Default)]
 pub struct BusySpinWithSpinLoopHint;
 
 impl WaitStrategy for BusySpinWithSpinLoopHint {
-	fn wait_for(&self, _sequence: Sequence) {
-		hint::spin_loop();
-	}
+    type Waiter = BusySpinWithSpinLoopHintWaiter;
+    type Notifier = NoopWakeupNotifier;
+
+    fn new_waiter(&self) -> Self::Waiter {
+        BusySpinWithSpinLoopHintWaiter
+    }
+
+    #[inline]
+    fn notifier(&self) -> Self::Notifier {
+        NoopWakeupNotifier
+    }
+}
+
+/// State holder for [`BusySpinWithSpinLoopHint`] wait strategy.
+pub struct BusySpinWithSpinLoopHintWaiter;
+
+impl Waiter for BusySpinWithSpinLoopHintWaiter {
+    fn wait_for(
+        &mut self,
+        requested: Sequence,
+        barrier: &impl Barrier,
+        shutdown: &CachePadded<AtomicI64>,
+    ) -> WaitOutcome {
+        loop {
+            if shutdown.load(Ordering::Relaxed) == requested {
+                return WaitOutcome::Shutdown;
+            }
+
+            let available = barrier.get_after(requested);
+            if available >= requested {
+                fence(Ordering::Acquire);
+                return WaitOutcome::Available { upper: available };
+            }
+
+            hint::spin_loop();
+        }
+    }
+}
+
+const SPIN_TRIES: u32 = 100;
+
+/// Yielding wait strategy: spin for a while, then yield the thread.
+///
+/// This mirrors the Java Disruptor's `YieldingWaitStrategy`, trading a small increase in latency
+/// for reduced CPU usage under contention.
+#[derive(Clone, Copy, Default)]
+pub struct YieldingWaitStrategy;
+
+impl WaitStrategy for YieldingWaitStrategy {
+    type Waiter = YieldingWaiter;
+    type Notifier = NoopWakeupNotifier;
+
+    fn new_waiter(&self) -> Self::Waiter {
+        YieldingWaiter {
+            spins_remaining: SPIN_TRIES,
+        }
+    }
+
+    #[inline]
+    fn notifier(&self) -> Self::Notifier {
+        NoopWakeupNotifier
+    }
+}
+
+/// State holder for [`YieldingWaitStrategy`].
+pub struct YieldingWaiter {
+    spins_remaining: u32,
+}
+
+impl Waiter for YieldingWaiter {
+    fn wait_for(
+        &mut self,
+        requested: Sequence,
+        barrier: &impl Barrier,
+        shutdown: &CachePadded<AtomicI64>,
+    ) -> WaitOutcome {
+        // Reset budget for this wait invocation.
+        self.spins_remaining = SPIN_TRIES;
+        loop {
+            if shutdown.load(Ordering::Relaxed) == requested {
+                return WaitOutcome::Shutdown;
+            }
+
+            let available = barrier.get_after(requested);
+            if available >= requested {
+                fence(Ordering::Acquire);
+                return WaitOutcome::Available { upper: available };
+            }
+
+            if self.spins_remaining > 0 {
+                self.spins_remaining -= 1;
+                hint::spin_loop();
+            } else {
+                thread::yield_now();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicI64;
+
+    struct TestBarrier {
+        available: std::sync::Arc<AtomicI64>,
+    }
+
+    impl TestBarrier {
+        fn new(v: i64) -> Self {
+            Self {
+                available: std::sync::Arc::new(AtomicI64::new(v)),
+            }
+        }
+    }
+
+    impl Barrier for TestBarrier {
+        fn get_after(&self, _prev: Sequence) -> Sequence {
+            self.available.load(Ordering::Relaxed)
+        }
+    }
+
+    #[test]
+    fn yielding_waiter_resets_spin_budget_each_wait() {
+        let mut waiter = YieldingWaiter {
+            spins_remaining: 0, // force-reset to prove it is restored
+        };
+        let barrier = TestBarrier::new(5);
+        let shutdown = CachePadded::new(AtomicI64::new(-1));
+
+        // immediate availability: should reset and return without consuming spins
+        let available = waiter.wait_for(5, &barrier, &shutdown);
+        assert!(matches!(available, WaitOutcome::Available { upper: 5 }));
+        assert_eq!(waiter.spins_remaining, SPIN_TRIES);
+
+        // withhold availability briefly to consume budget, then release
+        let barrier = TestBarrier::new(4); // less than requested
+        let shutdown = CachePadded::new(AtomicI64::new(-1));
+        let barrier_ref = barrier.available.clone();
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_micros(50));
+            barrier_ref.store(6, Ordering::Relaxed);
+        });
+        let _ = waiter.wait_for(6, &barrier, &shutdown);
+        handle.join().unwrap();
+
+        // Next call should start with a fresh spin budget.
+        let barrier = TestBarrier::new(7);
+        let shutdown = CachePadded::new(AtomicI64::new(-1));
+        let _ = waiter.wait_for(7, &barrier, &shutdown);
+        assert_eq!(waiter.spins_remaining, SPIN_TRIES);
+    }
+
+    #[test]
+    fn yielding_waiter_honors_shutdown() {
+        let mut waiter = YieldingWaiter {
+            spins_remaining: SPIN_TRIES,
+        };
+        let barrier = TestBarrier::new(-1);
+        let shutdown = CachePadded::new(AtomicI64::new(10));
+
+        let res = waiter.wait_for(10, &barrier, &shutdown);
+        assert!(matches!(res, WaitOutcome::Shutdown));
+    }
+
+    #[test]
+    fn busy_spin_waiter_observes_release_with_acquire_fence() {
+        let mut waiter = BusySpinWaiter;
+        let shutdown = std::sync::Arc::new(CachePadded::new(AtomicI64::new(-1)));
+        let data = std::sync::Arc::new(AtomicI64::new(0));
+        let barrier = TestBarrier::new(0);
+        let barrier_for_thread = barrier.available.clone();
+        let data_for_thread = data.clone();
+
+        // Writer thread publishes data with Release before making sequence available.
+        let handle = std::thread::spawn(move || {
+            data_for_thread.store(1, Ordering::Release);
+            barrier_for_thread.store(1, Ordering::Release);
+        });
+
+        // Wait for sequence 1; fence inside waiter should make the data visible.
+        let available = waiter.wait_for(1, &barrier, shutdown.as_ref());
+        assert!(matches!(available, WaitOutcome::Available { upper: 1 }));
+        assert_eq!(data.load(Ordering::Acquire), 1);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn busy_spin_waiter_exits_on_shutdown_race() {
+        let mut waiter = BusySpinWaiter;
+        let barrier = TestBarrier::new(-1);
+        let shutdown = std::sync::Arc::new(CachePadded::new(AtomicI64::new(-1)));
+
+        // Flip shutdown while waiter would otherwise spin.
+        let shutdown_ref = shutdown.clone();
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_micros(50));
+            shutdown_ref.store(5, Ordering::Relaxed);
+        });
+
+        let res = waiter.wait_for(5, &barrier, shutdown.as_ref());
+        assert!(matches!(res, WaitOutcome::Shutdown));
+        handle.join().unwrap();
+    }
 }


### PR DESCRIPTION
- Added cache-padded DependentSequence plus MultiConsumerDependentsBarrier and builder helpers
    'and_then_with_dependents' so downstream stages can be externally gated (docs + WAL example in
    README) (src/sequence.rs, src/consumer.rs, src/builder/single.rs, src/builder/multi.rs, README.md).
- Refactored wait strategies to use stateful Waiter/WakeupNotifier with WaitOutcome handling; producers
    now wake waiters after publish and a new YieldingWaitStrategy is available (src/wait_strategies.rs, src/
    consumer.rs, src/producer/single.rs, src/producer/multi.rs).
- Public exports and generics carry the wait strategy/notifier types (breaking for custom strategies);
    re-exported DependentSequence/YieldingWaitStrategy and tightened alignment guarantees (src/lib.rs, src/
    builder.rs, src/producer.rs).
- Broadened tests for gating/backpressure, fan-out minimum sequencing, wait-fence correctness, and dependent
    alignment; benches updated to the new API surface (src/lib.rs, src/wait_strategies.rs, src/consumer.rs,
    benches/*).
