### PR TITLE
Add diamond/DAG topology support for EventPollers

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -195,6 +195,7 @@ pub struct Shared<E, W> {
 	pub(crate) shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
 	pub(crate) ring_buffer:          Arc<RingBuffer<E>>,
 	pub(crate) consumers:            Vec<Consumer>,
+	pub(crate) producer_gating_cursors: Vec<Arc<Cursor>>,
 	current_consumer_cursors:        Option<Vec<Arc<Cursor>>>,
 	pub(crate) wait_strategy:        W,
 	pub(crate) thread_context:       ThreadContext,
@@ -215,8 +216,13 @@ impl <E, W> Shared<E, W> {
 			shutdown_at_sequence,
 			current_consumer_cursors,
 			consumers: vec![],
+			producer_gating_cursors: vec![],
 			thread_context: ThreadContext::default(),
 		}
+	}
+
+	pub(crate) fn add_producer_gating_cursor(&mut self, cursor: Arc<Cursor>) {
+		self.producer_gating_cursors.push(cursor);
 	}
 
 	fn add_consumer_and_cursor(&mut self, consumer: Consumer, cursor: Arc<Cursor>) {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -225,6 +225,11 @@ impl <E, W> Shared<E, W> {
 		self.producer_gating_cursors.push(cursor);
 	}
 
+	pub(crate) fn add_branch_consumer_and_cursor(&mut self, consumer: Consumer, cursor: Arc<Cursor>) {
+		self.consumers.push(consumer);
+		self.add_producer_gating_cursor(cursor);
+	}
+
 	fn add_consumer_and_cursor(&mut self, consumer: Consumer, cursor: Arc<Cursor>) {
 		self.consumers.push(consumer);
 		self.add_cursor(cursor);

--- a/src/builder/multi.rs
+++ b/src/builder/multi.rs
@@ -4,7 +4,7 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
-use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::EventPoller, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::{Cursor, CursorHandle}, producer::multi::{MultiProducer, MultiProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
+use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::{BranchPoller, EventPoller}, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::{BranchJoinHandle, Cursor, CursorHandle}, producer::multi::{MultiProducer, MultiProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
 
 use super::{Builder, Shared, MC, NC, SC};
 
@@ -31,20 +31,22 @@ where
 	///
 	/// This is intended for building DAG topologies where a branch runs in parallel with multiple
 	/// stages, and is only joined back at a later point (use [`and_then_joining`](Self::and_then_joining)).
+	/// Use [`BranchPoller::join_handle`] to obtain a handle that can be joined downstream.
 	///
 	/// This poller participates in producer back-pressure, but does not affect the builder's
 	/// dependency chain unless it is explicitly joined.
 	///
 	/// Note: Dropping the returned poller without advancing it can cause producers to eventually
 	/// stall when the ring buffer wraps, since it participates in producer back-pressure.
-	pub fn branch_poller(&mut self) -> EventPoller<E, B> {
+	pub fn branch_poller(&mut self) -> BranchPoller<E, B> {
 		let cursor = Arc::new(Cursor::new(-1));
 		self.shared.add_producer_gating_cursor(Arc::clone(&cursor));
-		EventPoller::new(
+		let poller = EventPoller::new(
 			Arc::clone(&self.shared.ring_buffer),
 			Arc::clone(&self.dependent_barrier),
 			Arc::clone(&self.shared.shutdown_at_sequence),
-			cursor)
+			Arc::clone(&cursor));
+		BranchPoller::new(poller, BranchJoinHandle(cursor))
 	}
 }
 

--- a/src/builder/multi.rs
+++ b/src/builder/multi.rs
@@ -4,7 +4,7 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
-use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::EventPoller, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::Cursor, producer::multi::{MultiProducer, MultiProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
+use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::EventPoller, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::{Cursor, CursorHandle}, producer::multi::{MultiProducer, MultiProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
 
 use super::{Builder, Shared, MC, NC, SC};
 
@@ -27,19 +27,22 @@ where
 	E: 'static + Send + Sync,
 	B: 'static + Barrier,
 {
-	/// Create an out-of-band [`EventPoller`] that depends on an earlier consumer's cursor.
+	/// Create an out-of-band [`EventPoller`] that depends on the current barrier.
 	///
-	/// This is intended for building diamond/DAG topologies where a downstream consumer must wait
-	/// for multiple independent branches to complete (use `and_then_joining(...)`).
+	/// This is intended for building DAG topologies where a branch runs in parallel with multiple
+	/// stages, and is only joined back at a later point (use [`and_then_joining`](Self::and_then_joining)).
 	///
-	/// Warning: If this poller is not joined into a downstream dependency chain (or otherwise included
-	/// in producer back-pressure), producers may overwrite slots before this poller has read them.
-	pub fn branch_poller(&mut self, depends_on: Arc<Cursor>) -> EventPoller<E, SingleConsumerBarrier> {
-		let barrier = Arc::new(SingleConsumerBarrier::new(depends_on));
-		let cursor  = Arc::new(Cursor::new(-1));
+	/// This poller participates in producer back-pressure, but does not affect the builder's
+	/// dependency chain unless it is explicitly joined.
+	///
+	/// Note: Dropping the returned poller without advancing it can cause producers to eventually
+	/// stall when the ring buffer wraps, since it participates in producer back-pressure.
+	pub fn branch_poller(&mut self) -> EventPoller<E, B> {
+		let cursor = Arc::new(Cursor::new(-1));
+		self.shared.add_producer_gating_cursor(Arc::clone(&cursor));
 		EventPoller::new(
 			Arc::clone(&self.shared.ring_buffer),
-			barrier,
+			Arc::clone(&self.dependent_barrier),
 			Arc::clone(&self.shared.shutdown_at_sequence),
 			cursor)
 	}
@@ -183,12 +186,12 @@ where
 
 	/// Like [`and_then`](Self::and_then) but the resulting barrier also waits for extra cursors
 	/// from other branches (e.g. created via [`branch_poller`](Self::branch_poller)).
-	pub fn and_then_joining(mut self, extra_cursors: Vec<Arc<Cursor>>) -> MPBuilder<NC, E, W, MultiConsumerBarrier> {
+	pub fn and_then_joining(mut self, extra_cursors: Vec<CursorHandle>) -> MPBuilder<NC, E, W, MultiConsumerBarrier> {
 		// Guaranteed to be present by construction.
 		let consumer_cursors  = self.shared().current_consumer_cursors.as_mut().unwrap();
 		let mut all_cursors   = Vec::with_capacity(1 + extra_cursors.len());
 		all_cursors.push(consumer_cursors.remove(0));
-		all_cursors.extend(extra_cursors);
+		all_cursors.extend(extra_cursors.into_iter().map(|c| c.0));
 		let dependent_barrier = Arc::new(MultiConsumerBarrier::new(all_cursors));
 
 		MPBuilder {
@@ -202,8 +205,15 @@ where
 	/// Finish the build and get a [`MultiProducer`].
 	pub fn build(mut self) -> MultiProducer<E, SingleConsumerBarrier> {
 		let mut consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
+		let mut producer_gating_cursors = std::mem::take(&mut self.shared.producer_gating_cursors);
 		// Guaranteed to be present by construction.
-		let consumer_barrier     = SingleConsumerBarrier::new(consumer_cursors.remove(0));
+		let consumer_cursor      = consumer_cursors.remove(0);
+		let consumer_barrier     = if producer_gating_cursors.is_empty() {
+			SingleConsumerBarrier::new(consumer_cursor)
+		} else {
+			producer_gating_cursors.push(consumer_cursor);
+			SingleConsumerBarrier::new_many(producer_gating_cursors)
+		};
 		MultiProducer::new(
 			self.shared.shutdown_at_sequence,
 			self.shared.ring_buffer,
@@ -267,11 +277,11 @@ where
 
 	/// Like [`and_then`](Self::and_then) but the resulting barrier also waits for extra cursors
 	/// from other branches (e.g. created via [`branch_poller`](Self::branch_poller)).
-	pub fn and_then_joining(mut self, extra_cursors: Vec<Arc<Cursor>>) -> MPBuilder<NC, E, W, MultiConsumerBarrier> {
+	pub fn and_then_joining(mut self, extra_cursors: Vec<CursorHandle>) -> MPBuilder<NC, E, W, MultiConsumerBarrier> {
 		let consumer_cursors  = self.shared().current_consumer_cursors.replace(vec![]).unwrap();
 		let mut all_cursors   = Vec::with_capacity(consumer_cursors.len() + extra_cursors.len());
 		all_cursors.extend(consumer_cursors);
-		all_cursors.extend(extra_cursors);
+		all_cursors.extend(extra_cursors.into_iter().map(|c| c.0));
 		let dependent_barrier = Arc::new(MultiConsumerBarrier::new(all_cursors));
 
 		MPBuilder {
@@ -284,7 +294,8 @@ where
 
 	/// Finish the build and get a [`MultiProducer`].
 	pub fn build(mut self) -> MultiProducer<E, MultiConsumerBarrier> {
-		let consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
+		let mut consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
+		consumer_cursors.extend(std::mem::take(&mut self.shared.producer_gating_cursors));
 		let consumer_barrier = MultiConsumerBarrier::new(consumer_cursors);
 		MultiProducer::new(
 			self.shared.shutdown_at_sequence,

--- a/src/builder/multi.rs
+++ b/src/builder/multi.rs
@@ -4,7 +4,7 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
-use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::{BranchPoller, EventPoller}, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::{BranchJoinHandle, Cursor, CursorHandle}, producer::multi::{MultiProducer, MultiProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
+use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::{BranchPoller, EventPoller}, start_processor, start_processor_with_state, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::{BranchJoinHandle, Cursor, CursorHandle}, producer::multi::{MultiProducer, MultiProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
 
 use super::{Builder, Shared, MC, NC, SC};
 
@@ -47,6 +47,41 @@ where
 			Arc::clone(&self.shared.shutdown_at_sequence),
 			Arc::clone(&cursor));
 		BranchPoller::new(poller, BranchJoinHandle(cursor))
+	}
+}
+
+impl<S, E, W, B> MPBuilder<S, E, W, B>
+where
+	E: 'static + Send + Sync,
+	W: 'static + WaitStrategy,
+	B: 'static + Barrier,
+{
+	/// Create an out-of-band processor that depends on the current barrier.
+	///
+	/// Like [`branch_poller`](Self::branch_poller), this is intended for wiring DAG topologies where
+	/// a branch runs in parallel with multiple stages and is only joined back later.
+	///
+	/// Returns a join handle that can be moved into [`and_then_joining`](Self::and_then_joining).
+	pub fn branch_handle_events_with<EH>(&mut self, event_handler: EH) -> BranchJoinHandle
+	where
+		EH: 'static + Send + FnMut(&E, Sequence, bool),
+	{
+		let barrier            = Arc::clone(&self.dependent_barrier);
+		let (cursor, consumer) = start_processor(event_handler, &mut self.shared, barrier);
+		self.shared.add_branch_consumer_and_cursor(consumer, Arc::clone(&cursor));
+		BranchJoinHandle(cursor)
+	}
+
+	/// Like [`branch_handle_events_with`](Self::branch_handle_events_with), but with state.
+	pub fn branch_handle_events_and_state_with<EH, S2, IS>(&mut self, event_handler: EH, initialize_state: IS) -> BranchJoinHandle
+	where
+		EH: 'static + Send + FnMut(&mut S2, &E, Sequence, bool),
+		IS: 'static + Send + FnOnce() -> S2,
+	{
+		let barrier            = Arc::clone(&self.dependent_barrier);
+		let (cursor, consumer) = start_processor_with_state(event_handler, &mut self.shared, barrier, initialize_state);
+		self.shared.add_branch_consumer_and_cursor(consumer, Arc::clone(&cursor));
+		BranchJoinHandle(cursor)
 	}
 }
 

--- a/src/builder/multi.rs
+++ b/src/builder/multi.rs
@@ -242,21 +242,16 @@ where
 	/// Finish the build and get a [`MultiProducer`].
 	pub fn build(mut self) -> MultiProducer<E, SingleConsumerBarrier> {
 		let mut consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
-		let mut producer_gating_cursors = std::mem::take(&mut self.shared.producer_gating_cursors);
+		let producer_gating_cursors = std::mem::take(&mut self.shared.producer_gating_cursors);
 		// Guaranteed to be present by construction.
-		let consumer_cursor      = consumer_cursors.remove(0);
-		let consumer_barrier     = if producer_gating_cursors.is_empty() {
-			SingleConsumerBarrier::new(consumer_cursor)
-		} else {
-			producer_gating_cursors.push(consumer_cursor);
-			SingleConsumerBarrier::new_many(producer_gating_cursors)
-		};
+		let consumer_barrier     = SingleConsumerBarrier::new(consumer_cursors.remove(0));
 		MultiProducer::new(
 			self.shared.shutdown_at_sequence,
 			self.shared.ring_buffer,
 			self.producer_barrier,
 			self.shared.consumers,
-			consumer_barrier)
+			consumer_barrier,
+			producer_gating_cursors)
 	}
 }
 
@@ -339,6 +334,7 @@ where
 			self.shared.ring_buffer,
 			self.producer_barrier,
 			self.shared.consumers,
-			consumer_barrier)
+			consumer_barrier,
+			vec![])
 	}
 }

--- a/src/builder/multi.rs
+++ b/src/builder/multi.rs
@@ -4,7 +4,7 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
-use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::EventPoller, MultiConsumerBarrier, SingleConsumerBarrier}, producer::multi::{MultiProducer, MultiProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
+use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::EventPoller, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::Cursor, producer::multi::{MultiProducer, MultiProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
 
 use super::{Builder, Shared, MC, NC, SC};
 
@@ -19,6 +19,29 @@ pub struct MPBuilder<State, E, W, B> {
 impl<S, E, W, B> ProcessorSettings<E, W> for MPBuilder<S, E, W, B> {
 	fn shared(&mut self) -> &mut Shared<E, W> {
 		&mut self.shared
+	}
+}
+
+impl<S, E, W, B> MPBuilder<S, E, W, B>
+where
+	E: 'static + Send + Sync,
+	B: 'static + Barrier,
+{
+	/// Create an out-of-band [`EventPoller`] that depends on an earlier consumer's cursor.
+	///
+	/// This is intended for building diamond/DAG topologies where a downstream consumer must wait
+	/// for multiple independent branches to complete (use `and_then_joining(...)`).
+	///
+	/// Warning: If this poller is not joined into a downstream dependency chain (or otherwise included
+	/// in producer back-pressure), producers may overwrite slots before this poller has read them.
+	pub fn branch_poller(&mut self, depends_on: Arc<Cursor>) -> EventPoller<E, SingleConsumerBarrier> {
+		let barrier = Arc::new(SingleConsumerBarrier::new(depends_on));
+		let cursor  = Arc::new(Cursor::new(-1));
+		EventPoller::new(
+			Arc::clone(&self.shared.ring_buffer),
+			barrier,
+			Arc::clone(&self.shared.shutdown_at_sequence),
+			cursor)
 	}
 }
 
@@ -158,6 +181,24 @@ where
 		}
 	}
 
+	/// Like [`and_then`](Self::and_then) but the resulting barrier also waits for extra cursors
+	/// from other branches (e.g. created via [`branch_poller`](Self::branch_poller)).
+	pub fn and_then_joining(mut self, extra_cursors: Vec<Arc<Cursor>>) -> MPBuilder<NC, E, W, MultiConsumerBarrier> {
+		// Guaranteed to be present by construction.
+		let consumer_cursors  = self.shared().current_consumer_cursors.as_mut().unwrap();
+		let mut all_cursors   = Vec::with_capacity(1 + extra_cursors.len());
+		all_cursors.push(consumer_cursors.remove(0));
+		all_cursors.extend(extra_cursors);
+		let dependent_barrier = Arc::new(MultiConsumerBarrier::new(all_cursors));
+
+		MPBuilder {
+			dependent_barrier,
+			state:            PhantomData,
+			shared:           self.shared,
+			producer_barrier: self.producer_barrier,
+		}
+	}
+
 	/// Finish the build and get a [`MultiProducer`].
 	pub fn build(mut self) -> MultiProducer<E, SingleConsumerBarrier> {
 		let mut consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
@@ -221,6 +262,23 @@ where
 			shared:           self.shared,
 			producer_barrier: self.producer_barrier,
 			dependent_barrier,
+		}
+	}
+
+	/// Like [`and_then`](Self::and_then) but the resulting barrier also waits for extra cursors
+	/// from other branches (e.g. created via [`branch_poller`](Self::branch_poller)).
+	pub fn and_then_joining(mut self, extra_cursors: Vec<Arc<Cursor>>) -> MPBuilder<NC, E, W, MultiConsumerBarrier> {
+		let consumer_cursors  = self.shared().current_consumer_cursors.replace(vec![]).unwrap();
+		let mut all_cursors   = Vec::with_capacity(consumer_cursors.len() + extra_cursors.len());
+		all_cursors.extend(consumer_cursors);
+		all_cursors.extend(extra_cursors);
+		let dependent_barrier = Arc::new(MultiConsumerBarrier::new(all_cursors));
+
+		MPBuilder {
+			dependent_barrier,
+			state:            PhantomData,
+			shared:           self.shared,
+			producer_barrier: self.producer_barrier,
 		}
 	}
 

--- a/src/builder/single.rs
+++ b/src/builder/single.rs
@@ -4,7 +4,7 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
-use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::EventPoller, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::{Cursor, CursorHandle}, producer::single::{SingleProducer, SingleProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
+use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::{BranchPoller, EventPoller}, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::{BranchJoinHandle, Cursor, CursorHandle}, producer::single::{SingleProducer, SingleProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
 
 use super::{Builder, Shared, MC, NC, SC};
 
@@ -31,20 +31,22 @@ where
 	///
 	/// This is intended for building DAG topologies where a branch runs in parallel with multiple
 	/// stages, and is only joined back at a later point (use [`and_then_joining`](Self::and_then_joining)).
+	/// Use [`BranchPoller::join_handle`] to obtain a handle that can be joined downstream.
 	///
 	/// This poller participates in producer back-pressure, but does not affect the builder's
 	/// dependency chain unless it is explicitly joined.
 	///
 	/// Note: Dropping the returned poller without advancing it can cause producers to eventually
 	/// stall when the ring buffer wraps, since it participates in producer back-pressure.
-	pub fn branch_poller(&mut self) -> EventPoller<E, B> {
+	pub fn branch_poller(&mut self) -> BranchPoller<E, B> {
 		let cursor = Arc::new(Cursor::new(-1));
 		self.shared.add_producer_gating_cursor(Arc::clone(&cursor));
-		EventPoller::new(
+		let poller = EventPoller::new(
 			Arc::clone(&self.shared.ring_buffer),
 			Arc::clone(&self.dependent_barrier),
 			Arc::clone(&self.shared.shutdown_at_sequence),
-			cursor)
+			Arc::clone(&cursor));
+		BranchPoller::new(poller, BranchJoinHandle(cursor))
 	}
 }
 

--- a/src/builder/single.rs
+++ b/src/builder/single.rs
@@ -4,7 +4,7 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
-use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::{BranchPoller, EventPoller}, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::{BranchJoinHandle, Cursor, CursorHandle}, producer::single::{SingleProducer, SingleProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
+use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::{BranchPoller, EventPoller}, start_processor, start_processor_with_state, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::{BranchJoinHandle, Cursor, CursorHandle}, producer::single::{SingleProducer, SingleProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
 
 use super::{Builder, Shared, MC, NC, SC};
 
@@ -47,6 +47,41 @@ where
 			Arc::clone(&self.shared.shutdown_at_sequence),
 			Arc::clone(&cursor));
 		BranchPoller::new(poller, BranchJoinHandle(cursor))
+	}
+}
+
+impl<E, W, B, S> SPBuilder<S, E, W, B>
+where
+	E: 'static + Send + Sync,
+	W: 'static + WaitStrategy,
+	B: 'static + Barrier,
+{
+	/// Create an out-of-band processor that depends on the current barrier.
+	///
+	/// Like [`branch_poller`](Self::branch_poller), this is intended for wiring DAG topologies where
+	/// a branch runs in parallel with multiple stages and is only joined back later.
+	///
+	/// Returns a join handle that can be moved into [`and_then_joining`](Self::and_then_joining).
+	pub fn branch_handle_events_with<EH>(&mut self, event_handler: EH) -> BranchJoinHandle
+	where
+		EH: 'static + Send + FnMut(&E, Sequence, bool),
+	{
+		let barrier            = Arc::clone(&self.dependent_barrier);
+		let (cursor, consumer) = start_processor(event_handler, &mut self.shared, barrier);
+		self.shared.add_branch_consumer_and_cursor(consumer, Arc::clone(&cursor));
+		BranchJoinHandle(cursor)
+	}
+
+	/// Like [`branch_handle_events_with`](Self::branch_handle_events_with), but with state.
+	pub fn branch_handle_events_and_state_with<EH, S2, IS>(&mut self, event_handler: EH, initialize_state: IS) -> BranchJoinHandle
+	where
+		EH: 'static + Send + FnMut(&mut S2, &E, Sequence, bool),
+		IS: 'static + Send + FnOnce() -> S2,
+	{
+		let barrier            = Arc::clone(&self.dependent_barrier);
+		let (cursor, consumer) = start_processor_with_state(event_handler, &mut self.shared, barrier, initialize_state);
+		self.shared.add_branch_consumer_and_cursor(consumer, Arc::clone(&cursor));
+		BranchJoinHandle(cursor)
 	}
 }
 

--- a/src/builder/single.rs
+++ b/src/builder/single.rs
@@ -167,21 +167,16 @@ where
 	/// Finish the build and get a [`SingleProducer`].
 	pub fn build(mut self) -> SingleProducer<E, SingleConsumerBarrier> {
 		let mut consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
-		let mut producer_gating_cursors = std::mem::take(&mut self.shared.producer_gating_cursors);
+		let producer_gating_cursors = std::mem::take(&mut self.shared.producer_gating_cursors);
 		// Guaranteed to be present by construction.
-		let consumer_cursor      = consumer_cursors.remove(0);
-		let consumer_barrier     = if producer_gating_cursors.is_empty() {
-			SingleConsumerBarrier::new(consumer_cursor)
-		} else {
-			producer_gating_cursors.push(consumer_cursor);
-			SingleConsumerBarrier::new_many(producer_gating_cursors)
-		};
+		let consumer_barrier     = SingleConsumerBarrier::new(consumer_cursors.remove(0));
 		SingleProducer::new(
 			self.shared.shutdown_at_sequence,
 			self.shared.ring_buffer,
 			self.producer_barrier,
 			self.shared.consumers,
-		consumer_barrier)
+			consumer_barrier,
+			producer_gating_cursors)
 	}
 
 	/// Get an EventPoller.
@@ -339,6 +334,7 @@ where
 			self.shared.ring_buffer,
 			self.producer_barrier,
 			self.shared.consumers,
-			consumer_barrier)
+			consumer_barrier,
+			vec![])
 	}
 }

--- a/src/builder/single.rs
+++ b/src/builder/single.rs
@@ -4,7 +4,7 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
-use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::EventPoller, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::Cursor, producer::single::{SingleProducer, SingleProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
+use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::EventPoller, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::{Cursor, CursorHandle}, producer::single::{SingleProducer, SingleProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
 
 use super::{Builder, Shared, MC, NC, SC};
 
@@ -27,19 +27,22 @@ where
 	E: 'static + Send + Sync,
 	B: 'static + Barrier,
 {
-	/// Create an out-of-band [`EventPoller`] that depends on an earlier consumer's cursor.
+	/// Create an out-of-band [`EventPoller`] that depends on the current barrier.
 	///
-	/// This is intended for building diamond/DAG topologies where a downstream consumer must wait
-	/// for multiple independent branches to complete (use `and_then_joining(...)`).
+	/// This is intended for building DAG topologies where a branch runs in parallel with multiple
+	/// stages, and is only joined back at a later point (use [`and_then_joining`](Self::and_then_joining)).
 	///
-	/// Warning: If this poller is not joined into a downstream dependency chain (or otherwise included
-	/// in producer back-pressure), producers may overwrite slots before this poller has read them.
-	pub fn branch_poller(&mut self, depends_on: Arc<Cursor>) -> EventPoller<E, SingleConsumerBarrier> {
-		let barrier = Arc::new(SingleConsumerBarrier::new(depends_on));
-		let cursor  = Arc::new(Cursor::new(-1));
+	/// This poller participates in producer back-pressure, but does not affect the builder's
+	/// dependency chain unless it is explicitly joined.
+	///
+	/// Note: Dropping the returned poller without advancing it can cause producers to eventually
+	/// stall when the ring buffer wraps, since it participates in producer back-pressure.
+	pub fn branch_poller(&mut self) -> EventPoller<E, B> {
+		let cursor = Arc::new(Cursor::new(-1));
+		self.shared.add_producer_gating_cursor(Arc::clone(&cursor));
 		EventPoller::new(
 			Arc::clone(&self.shared.ring_buffer),
-			barrier,
+			Arc::clone(&self.dependent_barrier),
 			Arc::clone(&self.shared.shutdown_at_sequence),
 			cursor)
 	}
@@ -127,8 +130,15 @@ where
 	/// Finish the build and get a [`SingleProducer`].
 	pub fn build(mut self) -> SingleProducer<E, SingleConsumerBarrier> {
 		let mut consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
+		let mut producer_gating_cursors = std::mem::take(&mut self.shared.producer_gating_cursors);
 		// Guaranteed to be present by construction.
-		let consumer_barrier     = SingleConsumerBarrier::new(consumer_cursors.remove(0));
+		let consumer_cursor      = consumer_cursors.remove(0);
+		let consumer_barrier     = if producer_gating_cursors.is_empty() {
+			SingleConsumerBarrier::new(consumer_cursor)
+		} else {
+			producer_gating_cursors.push(consumer_cursor);
+			SingleConsumerBarrier::new_many(producer_gating_cursors)
+		};
 		SingleProducer::new(
 			self.shared.shutdown_at_sequence,
 			self.shared.ring_buffer,
@@ -167,12 +177,12 @@ where
 
 	/// Like [`and_then`](Self::and_then) but the resulting barrier also waits for extra cursors
 	/// from other branches (e.g. created via [`branch_poller`](Self::branch_poller)).
-	pub fn and_then_joining(mut self, extra_cursors: Vec<Arc<Cursor>>) -> SPBuilder<NC, E, W, MultiConsumerBarrier> {
+	pub fn and_then_joining(mut self, extra_cursors: Vec<CursorHandle>) -> SPBuilder<NC, E, W, MultiConsumerBarrier> {
 		// Guaranteed to be present by construction.
 		let consumer_cursors  = self.shared().current_consumer_cursors.as_mut().unwrap();
 		let mut all_cursors   = Vec::with_capacity(1 + extra_cursors.len());
 		all_cursors.push(consumer_cursors.remove(0));
-		all_cursors.extend(extra_cursors);
+		all_cursors.extend(extra_cursors.into_iter().map(|c| c.0));
 		let dependent_barrier = Arc::new(MultiConsumerBarrier::new(all_cursors));
 
 		SPBuilder {
@@ -267,11 +277,11 @@ where
 
 	/// Like [`and_then`](Self::and_then) but the resulting barrier also waits for extra cursors
 	/// from other branches (e.g. created via [`branch_poller`](Self::branch_poller)).
-	pub fn and_then_joining(mut self, extra_cursors: Vec<Arc<Cursor>>) -> SPBuilder<NC, E, W, MultiConsumerBarrier> {
+	pub fn and_then_joining(mut self, extra_cursors: Vec<CursorHandle>) -> SPBuilder<NC, E, W, MultiConsumerBarrier> {
 		let consumer_cursors  = self.shared().current_consumer_cursors.replace(vec![]).unwrap();
 		let mut all_cursors   = Vec::with_capacity(consumer_cursors.len() + extra_cursors.len());
 		all_cursors.extend(consumer_cursors);
-		all_cursors.extend(extra_cursors);
+		all_cursors.extend(extra_cursors.into_iter().map(|c| c.0));
 		let dependent_barrier = Arc::new(MultiConsumerBarrier::new(all_cursors));
 
 		SPBuilder {
@@ -284,7 +294,8 @@ where
 
 	/// Finish the build and get a [`SingleProducer`].
 	pub fn build(mut self) -> SingleProducer<E, MultiConsumerBarrier> {
-		let consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
+		let mut consumer_cursors = self.shared().current_consumer_cursors.take().unwrap();
+		consumer_cursors.extend(std::mem::take(&mut self.shared.producer_gating_cursors));
 		let consumer_barrier = MultiConsumerBarrier::new(consumer_cursors);
 		SingleProducer::new(
 			self.shared.shutdown_at_sequence,

--- a/src/builder/single.rs
+++ b/src/builder/single.rs
@@ -1,10 +1,10 @@
 //! Module for structs for building a Single Producer Disruptor in a type safe way.
 //!
-//! To get started building a Single Producer Disruptor, invoke [super::build_multi_producer].
+//! To get started building a Single Producer Disruptor, invoke [super::build_single_producer].
 
 use std::{marker::PhantomData, sync::Arc};
 
-use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::EventPoller, MultiConsumerBarrier, SingleConsumerBarrier}, producer::single::{SingleProducer, SingleProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
+use crate::{barrier::Barrier, builder::ProcessorSettings, consumer::{event_poller::EventPoller, MultiConsumerBarrier, SingleConsumerBarrier}, cursor::Cursor, producer::single::{SingleProducer, SingleProducerBarrier}, wait_strategies::WaitStrategy, Sequence};
 
 use super::{Builder, Shared, MC, NC, SC};
 
@@ -19,6 +19,29 @@ pub struct SPBuilder<State, E, W, B> {
 impl<E, W, B, S> ProcessorSettings<E, W> for SPBuilder<S, E, W, B> {
 	fn shared(&mut self) -> &mut Shared<E, W> {
 		&mut self.shared
+	}
+}
+
+impl<E, W, B, S> SPBuilder<S, E, W, B>
+where
+	E: 'static + Send + Sync,
+	B: 'static + Barrier,
+{
+	/// Create an out-of-band [`EventPoller`] that depends on an earlier consumer's cursor.
+	///
+	/// This is intended for building diamond/DAG topologies where a downstream consumer must wait
+	/// for multiple independent branches to complete (use `and_then_joining(...)`).
+	///
+	/// Warning: If this poller is not joined into a downstream dependency chain (or otherwise included
+	/// in producer back-pressure), producers may overwrite slots before this poller has read them.
+	pub fn branch_poller(&mut self, depends_on: Arc<Cursor>) -> EventPoller<E, SingleConsumerBarrier> {
+		let barrier = Arc::new(SingleConsumerBarrier::new(depends_on));
+		let cursor  = Arc::new(Cursor::new(-1));
+		EventPoller::new(
+			Arc::clone(&self.shared.ring_buffer),
+			barrier,
+			Arc::clone(&self.shared.shutdown_at_sequence),
+			cursor)
 	}
 }
 
@@ -142,6 +165,24 @@ where
 		}
 	}
 
+	/// Like [`and_then`](Self::and_then) but the resulting barrier also waits for extra cursors
+	/// from other branches (e.g. created via [`branch_poller`](Self::branch_poller)).
+	pub fn and_then_joining(mut self, extra_cursors: Vec<Arc<Cursor>>) -> SPBuilder<NC, E, W, MultiConsumerBarrier> {
+		// Guaranteed to be present by construction.
+		let consumer_cursors  = self.shared().current_consumer_cursors.as_mut().unwrap();
+		let mut all_cursors   = Vec::with_capacity(1 + extra_cursors.len());
+		all_cursors.push(consumer_cursors.remove(0));
+		all_cursors.extend(extra_cursors);
+		let dependent_barrier = Arc::new(MultiConsumerBarrier::new(all_cursors));
+
+		SPBuilder {
+			dependent_barrier,
+			state:            PhantomData,
+			shared:           self.shared,
+			producer_barrier: self.producer_barrier,
+		}
+	}
+
 	/// Add an event handler.
 	pub fn handle_events_with<EH>(mut self, event_handler: EH) -> SPBuilder<MC, E, W, B>
 	where
@@ -215,6 +256,23 @@ where
 	pub fn and_then(mut self) -> SPBuilder<NC, E, W, MultiConsumerBarrier> {
 		let consumer_cursors  = self.shared().current_consumer_cursors.replace(vec![]).unwrap();
 		let dependent_barrier = Arc::new(MultiConsumerBarrier::new(consumer_cursors));
+
+		SPBuilder {
+			dependent_barrier,
+			state:            PhantomData,
+			shared:           self.shared,
+			producer_barrier: self.producer_barrier,
+		}
+	}
+
+	/// Like [`and_then`](Self::and_then) but the resulting barrier also waits for extra cursors
+	/// from other branches (e.g. created via [`branch_poller`](Self::branch_poller)).
+	pub fn and_then_joining(mut self, extra_cursors: Vec<Arc<Cursor>>) -> SPBuilder<NC, E, W, MultiConsumerBarrier> {
+		let consumer_cursors  = self.shared().current_consumer_cursors.replace(vec![]).unwrap();
+		let mut all_cursors   = Vec::with_capacity(consumer_cursors.len() + extra_cursors.len());
+		all_cursors.extend(consumer_cursors);
+		all_cursors.extend(extra_cursors);
+		let dependent_barrier = Arc::new(MultiConsumerBarrier::new(all_cursors));
 
 		SPBuilder {
 			dependent_barrier,

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -22,9 +22,9 @@ impl Consumer {
 	}
 }
 
-/// Barrier tracking a single consumer.
+/// Barrier tracking (typically) a single consumer.
 pub struct SingleConsumerBarrier {
-	cursor: Arc<Cursor>
+	cursors: Vec<Arc<Cursor>>,
 }
 
 /// Barrier tracking the minimum sequence of a group of consumers.
@@ -35,15 +35,23 @@ pub struct MultiConsumerBarrier {
 impl SingleConsumerBarrier {
 	pub(crate) fn new(cursor: Arc<Cursor>) -> Self {
 		Self {
-			cursor
+			cursors: vec![cursor],
 		}
+	}
+
+	pub(crate) fn new_many(cursors: Vec<Arc<Cursor>>) -> Self {
+		assert!(!cursors.is_empty(), "SingleConsumerBarrier must have at least one cursor.");
+		Self { cursors }
 	}
 }
 
 impl Barrier for SingleConsumerBarrier {
 	#[inline]
 	fn get_after(&self, _lower_bound: Sequence) -> Sequence {
-		self.cursor.relaxed_value()
+		self.cursors.iter().fold(i64::MAX, |min_sequence, cursor| {
+			let sequence = cursor.relaxed_value();
+			std::cmp::min(sequence, min_sequence)
+		})
 	}
 }
 

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -22,7 +22,7 @@ impl Consumer {
 	}
 }
 
-/// Barrier tracking (typically) a single consumer.
+/// Barrier tracking the minimum sequence of one or more consumers (usually one).
 pub struct SingleConsumerBarrier {
 	cursors: Vec<Arc<Cursor>>,
 }

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -22,9 +22,9 @@ impl Consumer {
 	}
 }
 
-/// Barrier tracking the minimum sequence of one or more consumers (usually one).
+/// Barrier tracking a single consumer.
 pub struct SingleConsumerBarrier {
-	cursors: Vec<Arc<Cursor>>,
+	cursor: Arc<Cursor>
 }
 
 /// Barrier tracking the minimum sequence of a group of consumers.
@@ -35,23 +35,15 @@ pub struct MultiConsumerBarrier {
 impl SingleConsumerBarrier {
 	pub(crate) fn new(cursor: Arc<Cursor>) -> Self {
 		Self {
-			cursors: vec![cursor],
+			cursor
 		}
-	}
-
-	pub(crate) fn new_many(cursors: Vec<Arc<Cursor>>) -> Self {
-		assert!(!cursors.is_empty(), "SingleConsumerBarrier must have at least one cursor.");
-		Self { cursors }
 	}
 }
 
 impl Barrier for SingleConsumerBarrier {
 	#[inline]
 	fn get_after(&self, _lower_bound: Sequence) -> Sequence {
-		self.cursors.iter().fold(i64::MAX, |min_sequence, cursor| {
-			let sequence = cursor.relaxed_value();
-			std::cmp::min(sequence, min_sequence)
-		})
+		self.cursor.relaxed_value()
 	}
 }
 

--- a/src/consumer/event_poller.rs
+++ b/src/consumer/event_poller.rs
@@ -132,6 +132,14 @@ where
 		}
 	}
 
+	/// Returns a clone of this poller's cursor.
+	///
+	/// Used to wire diamond/DAG topologies where downstream consumers or join barriers
+	/// (e.g. `and_then_joining`) need to track this consumer's progress.
+	pub fn cursor(&self) -> Arc<Cursor> {
+		Arc::clone(&self.cursor)
+	}
+
 	/// Polls the ring buffer and returns an [`EventGuard`] if any events are available.
 	/// The guard can be used like an iterator and yields all available events at the time of polling.
 	/// Dropping the guard will signal to the Disruptor that the events have been processed.
@@ -173,6 +181,20 @@ where
 	/// ```
 	pub fn poll(&mut self) -> Result<EventGuard<'_, E, B>, Polling> {
 		self.poll_take(u64::MAX)
+	}
+
+	/// Returns `true` if there is at least one event available to poll.
+	///
+	/// This is a cheap check (no fence, no mutation) intended for use as a
+	/// double-check before blocking on a condition variable. It does NOT
+	/// advance the cursor or consume any events.
+	///
+	/// Note: This does not check for shutdown. Callers should still call [`poll`](Self::poll) /
+	/// [`poll_take`](Self::poll_take) and handle [`Polling::Shutdown`].
+	#[inline]
+	pub fn has_available(&self) -> bool {
+		let sequence = self.cursor.relaxed_value() + 1;
+		self.dependent_barrier.get_after(sequence) >= sequence
 	}
 
 	/// Polls for available events, yielding at most `limit` events.

--- a/src/consumer/event_poller.rs
+++ b/src/consumer/event_poller.rs
@@ -64,7 +64,7 @@ pub struct EventPoller<E, B> {
 #[must_use = "A branch poller participates in producer back-pressure. Dropping it without polling can cause producers to stall."]
 pub struct BranchPoller<E, B> {
 	poller:      EventPoller<E, B>,
-	join_handle: Option<BranchJoinHandle>,
+	join_handle: BranchJoinHandle,
 }
 
 /// Error types that can occur if polling is unsuccessful.
@@ -273,7 +273,7 @@ where
 	pub(crate) fn new(poller: EventPoller<E, B>, join_handle: BranchJoinHandle) -> Self {
 		Self {
 			poller,
-			join_handle: Some(join_handle),
+			join_handle,
 		}
 	}
 
@@ -281,23 +281,7 @@ where
 	///
 	/// The returned handle can be moved into `and_then_joining(...)` to join this branch into a
 	/// downstream dependency chain.
-	pub fn join_handle(&mut self) -> BranchJoinHandle {
-		self.join_handle.take().expect("Branch join handle already taken.")
-	}
-
-	/// Polls the ring buffer and returns an [`EventGuard`] if any events are available.
-	pub fn poll(&mut self) -> Result<EventGuard<'_, E, B>, Polling> {
-		self.poller.poll()
-	}
-
-	/// Polls for available events, yielding at most `limit` events.
-	pub fn poll_take(&mut self, limit: u64) -> Result<EventGuard<'_, E, B>, Polling> {
-		self.poller.poll_take(limit)
-	}
-
-	/// Returns `true` if there is at least one event available to poll.
-	#[inline]
-	pub fn has_available(&self) -> bool {
-		self.poller.has_available()
+	pub fn join_handle(self) -> (BranchJoinHandle, EventPoller<E, B>) {
+		(self.join_handle, self.poller)
 	}
 }

--- a/src/consumer/event_poller.rs
+++ b/src/consumer/event_poller.rs
@@ -1,7 +1,7 @@
 use std::{sync::{atomic::{fence, AtomicI64, Ordering}, Arc}};
 use crossbeam_utils::CachePadded;
 use thiserror::Error;
-use crate::{cursor::Cursor, barrier::Barrier, ringbuffer::RingBuffer, Sequence};
+use crate::{cursor::{Cursor, CursorHandle}, barrier::Barrier, ringbuffer::RingBuffer, Sequence};
 
 /// Represents an EventPoller that can be used to poll events from the ring buffer.
 /// Use the EventPoller when you want to control your own thread
@@ -132,12 +132,12 @@ where
 		}
 	}
 
-	/// Returns a clone of this poller's cursor.
+	/// Returns a clone of this poller's cursor handle.
 	///
-	/// Used to wire diamond/DAG topologies where downstream consumers or join barriers
+	/// Used to wire DAG topologies where downstream consumers or join barriers
 	/// (e.g. `and_then_joining`) need to track this consumer's progress.
-	pub fn cursor(&self) -> Arc<Cursor> {
-		Arc::clone(&self.cursor)
+	pub fn cursor(&self) -> CursorHandle {
+		CursorHandle(Arc::clone(&self.cursor))
 	}
 
 	/// Polls the ring buffer and returns an [`EventGuard`] if any events are available.

--- a/src/consumer/event_poller.rs
+++ b/src/consumer/event_poller.rs
@@ -1,7 +1,7 @@
 use std::{sync::{atomic::{fence, AtomicI64, Ordering}, Arc}};
 use crossbeam_utils::CachePadded;
 use thiserror::Error;
-use crate::{cursor::{Cursor, CursorHandle}, barrier::Barrier, ringbuffer::RingBuffer, Sequence};
+use crate::{cursor::{BranchJoinHandle, Cursor, CursorHandle}, barrier::Barrier, ringbuffer::RingBuffer, Sequence};
 
 /// Represents an EventPoller that can be used to poll events from the ring buffer.
 /// Use the EventPoller when you want to control your own thread
@@ -54,6 +54,17 @@ pub struct EventPoller<E, B> {
 	dependent_barrier:    Arc<B>,
 	shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
 	cursor:               Arc<Cursor>,
+}
+
+/// An [`EventPoller`] created via `branch_poller`, along with a non-cloneable join handle.
+///
+/// This wrapper exists so callers can wire DAG topologies without needing access to internal cursor
+/// types. Use [`join_handle`](Self::join_handle) to obtain a handle that can be joined into a
+/// downstream dependency chain.
+#[must_use = "A branch poller participates in producer back-pressure. Dropping it without polling can cause producers to stall."]
+pub struct BranchPoller<E, B> {
+	poller:      EventPoller<E, B>,
+	join_handle: Option<BranchJoinHandle>,
 }
 
 /// Error types that can occur if polling is unsuccessful.
@@ -252,5 +263,41 @@ where
 			sequence,
 			available,
 		})
+	}
+}
+
+impl<E, B> BranchPoller<E, B>
+where
+	B: Barrier,
+{
+	pub(crate) fn new(poller: EventPoller<E, B>, join_handle: BranchJoinHandle) -> Self {
+		Self {
+			poller,
+			join_handle: Some(join_handle),
+		}
+	}
+
+	/// Takes the join handle for this branch.
+	///
+	/// The returned handle can be moved into `and_then_joining(...)` to join this branch into a
+	/// downstream dependency chain.
+	pub fn join_handle(&mut self) -> BranchJoinHandle {
+		self.join_handle.take().expect("Branch join handle already taken.")
+	}
+
+	/// Polls the ring buffer and returns an [`EventGuard`] if any events are available.
+	pub fn poll(&mut self) -> Result<EventGuard<'_, E, B>, Polling> {
+		self.poller.poll()
+	}
+
+	/// Polls for available events, yielding at most `limit` events.
+	pub fn poll_take(&mut self, limit: u64) -> Result<EventGuard<'_, E, B>, Polling> {
+		self.poller.poll_take(limit)
+	}
+
+	/// Returns `true` if there is at least one event available to poll.
+	#[inline]
+	pub fn has_available(&self) -> bool {
+		self.poller.has_available()
 	}
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -22,6 +22,20 @@ pub(crate) struct Cursor {
 #[derive(Clone)]
 pub struct CursorHandle(pub(crate) Arc<Cursor>);
 
+/// Non-cloneable cursor handle for branch consumers/pollers.
+///
+/// This is primarily intended to be moved into APIs like
+/// [`SPBuilder::and_then_joining`](crate::builder::single::SPBuilder::and_then_joining) /
+/// [`MPBuilder::and_then_joining`](crate::builder::multi::MPBuilder::and_then_joining).
+#[must_use = "Dropping a branch join handle means the branch will not be joined into any downstream barrier."]
+pub struct BranchJoinHandle(pub(crate) Arc<Cursor>);
+
+impl From<BranchJoinHandle> for CursorHandle {
+	fn from(value: BranchJoinHandle) -> Self {
+		CursorHandle(value.0)
+	}
+}
+
 impl Cursor {
 	pub(crate) fn new(start_value: i64) -> Self {
 		Self {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,9 +1,16 @@
-use std::sync::atomic::{AtomicI64, Ordering};
 use crossbeam_utils::CachePadded;
+use std::sync::{
+	atomic::{AtomicI64, Ordering},
+	Arc,
+};
 
 use crate::Sequence;
 
-/// Opaque cursor used to coordinate dependencies between [`EventPoller`](crate::EventPoller)s.
+pub(crate) struct Cursor {
+	counter: CachePadded<AtomicI64>
+}
+
+/// Opaque cursor handle used to coordinate dependencies between consumers.
 ///
 /// This type is primarily intended to be passed between topology-building APIs such as
 /// [`SPBuilder::branch_poller`](crate::builder::single::SPBuilder::branch_poller),
@@ -11,10 +18,9 @@ use crate::Sequence;
 /// [`SPBuilder::and_then_joining`](crate::builder::single::SPBuilder::and_then_joining) /
 /// [`MPBuilder::and_then_joining`](crate::builder::multi::MPBuilder::and_then_joining).
 ///
-/// Obtain a cursor via [`EventPoller::cursor`](crate::EventPoller::cursor).
-pub struct Cursor {
-	counter: CachePadded<AtomicI64>
-}
+/// Obtain a cursor handle via [`EventPoller::cursor`](crate::EventPoller::cursor).
+#[derive(Clone)]
+pub struct CursorHandle(pub(crate) Arc<Cursor>);
 
 impl Cursor {
 	pub(crate) fn new(start_value: i64) -> Self {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -3,7 +3,16 @@ use crossbeam_utils::CachePadded;
 
 use crate::Sequence;
 
-pub(crate) struct Cursor {
+/// Opaque cursor used to coordinate dependencies between [`EventPoller`](crate::EventPoller)s.
+///
+/// This type is primarily intended to be passed between topology-building APIs such as
+/// [`SPBuilder::branch_poller`](crate::builder::single::SPBuilder::branch_poller),
+/// [`MPBuilder::branch_poller`](crate::builder::multi::MPBuilder::branch_poller), and
+/// [`SPBuilder::and_then_joining`](crate::builder::single::SPBuilder::and_then_joining) /
+/// [`MPBuilder::and_then_joining`](crate::builder::multi::MPBuilder::and_then_joining).
+///
+/// Obtain a cursor via [`EventPoller::cursor`](crate::EventPoller::cursor).
+pub struct Cursor {
 	counter: CachePadded<AtomicI64>
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,12 @@
 //! [`MPBuilder::and_then_joining`](builder::multi::MPBuilder::and_then_joining) to join it into the
 //! downstream dependency chain.
 //!
+//! You can also create a "managed" branch consumer (event handler) using
+//! [`SPBuilder::branch_handle_events_with`](builder::single::SPBuilder::branch_handle_events_with) /
+//! [`MPBuilder::branch_handle_events_with`](builder::multi::MPBuilder::branch_handle_events_with).
+//! These methods return a [`BranchJoinHandle`] that can be joined later via
+//! `and_then_joining(vec![join_handle.into()])`.
+//!
 //! Note: A branch poller participates in producer back-pressure. If you create one and never poll it,
 //! producers can eventually stall when the ring buffer wraps.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,7 @@ mod ringbuffer;
 mod producer;
 
 pub use crate::builder::{build_single_producer, build_multi_producer, ProcessorSettings};
+pub use crate::cursor::Cursor;
 pub use crate::producer::{Producer, RingBufferFull, MissingFreeSlots};
 pub use crate::wait_strategies::{BusySpin, BusySpinWithSpinLoopHint};
 pub use crate::producer::{single::{SingleProducer, SingleProducerBarrier}, multi::{MultiProducer,  MultiProducerBarrier}};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,8 @@
 //!
 //! Use [`SPBuilder::branch_poller`](builder::single::SPBuilder::branch_poller) /
 //! [`MPBuilder::branch_poller`](builder::multi::MPBuilder::branch_poller) to create a branch poller,
-//! and [`SPBuilder::and_then_joining`](builder::single::SPBuilder::and_then_joining) /
+//! take its join handle via [`BranchPoller::join_handle`], and then use
+//! [`SPBuilder::and_then_joining`](builder::single::SPBuilder::and_then_joining) /
 //! [`MPBuilder::and_then_joining`](builder::multi::MPBuilder::and_then_joining) to join it into the
 //! downstream dependency chain.
 //!
@@ -306,12 +307,12 @@ mod ringbuffer;
 mod producer;
 
 pub use crate::builder::{build_single_producer, build_multi_producer, ProcessorSettings};
-pub use crate::cursor::CursorHandle;
+pub use crate::cursor::{BranchJoinHandle, CursorHandle};
 pub use crate::producer::{Producer, RingBufferFull, MissingFreeSlots};
 pub use crate::wait_strategies::{BusySpin, BusySpinWithSpinLoopHint};
 pub use crate::producer::{single::{SingleProducer, SingleProducerBarrier}, multi::{MultiProducer,  MultiProducerBarrier}};
 pub use crate::consumer::{SingleConsumerBarrier, MultiConsumerBarrier};
-pub use crate::consumer::event_poller::{EventPoller, Polling, EventGuard};
+pub use crate::consumer::event_poller::{BranchPoller, EventPoller, Polling, EventGuard};
 
 #[cfg(test)]
 mod tests {
@@ -996,7 +997,8 @@ mod tests {
 		let (mut ep_r2, builder) = builder.event_poller();
 
 		// Report joins R2 and J.
-		let builder = builder.and_then_joining(vec![ep_j.cursor()]);
+		let j = ep_j.join_handle();
+		let builder = builder.and_then_joining(vec![j.into()]);
 		let (mut ep_report, builder) = builder.event_poller();
 
 		let mut producer = builder.build();
@@ -1100,7 +1102,8 @@ mod tests {
 		let (mut ep_r2, builder) = builder.event_poller();
 
 		// Report joins R2 and J.
-		let builder = builder.and_then_joining(vec![ep_j.cursor()]);
+		let j = ep_j.join_handle();
+		let builder = builder.and_then_joining(vec![j.into()]);
 		let (mut ep_report, builder) = builder.event_poller();
 
 		let mut producer1 = builder.build();
@@ -1221,7 +1224,10 @@ mod tests {
 		let (mut ep_a, builder) = builder.event_poller();
 
 		// Report joins A and J1/J2/J3.
-		let builder = builder.and_then_joining(vec![ep_j1.cursor(), ep_j2.cursor(), ep_j3.cursor()]);
+		let j1 = ep_j1.join_handle();
+		let j2 = ep_j2.join_handle();
+		let j3 = ep_j3.join_handle();
+		let builder = builder.and_then_joining(vec![j1.into(), j2.into(), j3.into()]);
 		let (mut ep_report, builder) = builder.event_poller();
 
 		let mut producer = builder.build();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,11 +270,15 @@
 //!
 //! ### Diamond / DAG Topology
 //!
-//! You can build diamond/DAG topologies by creating a branch [`EventPoller`] that depends on an
-//! earlier consumer and then joining it into a downstream barrier:
+//! You can build DAG topologies where a branch runs in parallel with multiple stages, and is only
+//! joined back at a later point.
+//!
+//! For example, a journaling poller `J` can run in parallel with a multi-stage pipeline, and the
+//! final stage can wait for both the pipeline and `J`:
 //!
 //! ```text
-//! Producer -> A -> [B (branch) || C] -> D (joins B + C)
+//! Producer -> R1 -> ME -> R2 ----\
+//! Producer -> J ---------------> Report (joins R2 + J)
 //! ```
 //!
 //! Use [`SPBuilder::branch_poller`](builder::single::SPBuilder::branch_poller) /
@@ -282,6 +286,9 @@
 //! and [`SPBuilder::and_then_joining`](builder::single::SPBuilder::and_then_joining) /
 //! [`MPBuilder::and_then_joining`](builder::multi::MPBuilder::and_then_joining) to join it into the
 //! downstream dependency chain.
+//!
+//! Note: A branch poller participates in producer back-pressure. If you create one and never poll it,
+//! producers can eventually stall when the ring buffer wraps.
 
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
@@ -971,23 +978,26 @@ mod tests {
 	}
 
 	#[test]
-	fn spsc_diamond_topology_with_event_pollers() {
-		let builder = build_single_producer(8, factory(), BusySpin);
+	fn spsc_branch_from_producer_joined_after_multiple_stages() {
+		let mut builder = build_single_producer(8, factory(), BusySpin);
 
-		// A depends on producer.
-		let (mut ep_a, mut builder) = builder.event_poller();
-		let a_cursor = ep_a.cursor();
+		// J depends on producer (out-of-band).
+		let mut ep_j = builder.branch_poller();
 
-		// B is a branch that depends on A (out-of-band).
-		let mut ep_b = builder.branch_poller(a_cursor.clone());
+		// R1 depends on producer.
+		let (mut ep_r1, builder) = builder.event_poller();
 
-		// C depends on A via and_then (main chain).
+		// ME depends on R1.
 		let builder = builder.and_then();
-		let (mut ep_c, builder) = builder.event_poller();
+		let (mut ep_me, builder) = builder.event_poller();
 
-		// D joins C and B.
-		let builder = builder.and_then_joining(vec![ep_b.cursor()]);
-		let (mut ep_d, builder) = builder.event_poller();
+		// R2 depends on ME.
+		let builder = builder.and_then();
+		let (mut ep_r2, builder) = builder.event_poller();
+
+		// Report joins R2 and J.
+		let builder = builder.and_then_joining(vec![ep_j.cursor()]);
+		let (mut ep_report, builder) = builder.event_poller();
 
 		let mut producer = builder.build();
 
@@ -999,39 +1009,44 @@ mod tests {
 
 		let expected = vec![10, 20, 30];
 
-		// B, C, D are blocked until A advances.
-		assert_eq!(ep_b.poll().err(), Some(Polling::NoEvents));
-		assert_eq!(ep_c.poll().err(), Some(Polling::NoEvents));
-		assert_eq!(ep_d.poll().err(), Some(Polling::NoEvents));
+		// Downstream stages are blocked until upstream stages advance.
+		assert_eq!(ep_me.poll().err(), Some(Polling::NoEvents));
+		assert_eq!(ep_r2.poll().err(), Some(Polling::NoEvents));
+		assert_eq!(ep_report.poll().err(), Some(Polling::NoEvents));
 
-		// A sees events first.
+		// J is independent of R1/ME/R2.
 		{
-			let mut guard = ep_a.poll().unwrap();
+			let mut guard = ep_j.poll().unwrap();
 			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
 		}
+		// Still blocked because R2 hasn't advanced.
+		assert_eq!(ep_report.poll().err(), Some(Polling::NoEvents));
 
-		// B can proceed after A, but D is still blocked by C.
+		// Progress the main pipeline.
 		{
-			let mut guard = ep_b.poll().unwrap();
-			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
-		}
-		assert_eq!(ep_d.poll().err(), Some(Polling::NoEvents));
-
-		// C can proceed after A. Now D can proceed after both B and C.
-		{
-			let mut guard = ep_c.poll().unwrap();
+			let mut guard = ep_r1.poll().unwrap();
 			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
 		}
 		{
-			let mut guard = ep_d.poll().unwrap();
+			let mut guard = ep_me.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut guard = ep_r2.poll().unwrap();
 			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
 		}
 
-		// All pollers see shutdown after draining.
-		assert_eq!(ep_a.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_b.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_c.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_d.poll().err(), Some(Polling::Shutdown));
+		// Now report can proceed after both R2 and J.
+		{
+			let mut guard = ep_report.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		assert_eq!(ep_j.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_r1.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_me.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_r2.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_report.poll().err(), Some(Polling::Shutdown));
 	}
 
 	#[test]
@@ -1041,7 +1056,7 @@ mod tests {
 		// A depends on producer.
 		let (mut ep_a, builder) = builder.event_poller();
 		// B depends on A via and_then_joining(vec![]) which should degrade to and_then().
-		let builder = builder.and_then_joining(vec![]);
+		let builder = builder.and_then_joining(Vec::<CursorHandle>::new());
 		let (mut ep_b, builder) = builder.event_poller();
 
 		let mut producer = builder.build();
@@ -1067,23 +1082,26 @@ mod tests {
 	}
 
 	#[test]
-	fn mpmc_diamond_topology_with_event_pollers() {
-		let builder = build_multi_producer(64, factory(), BusySpin);
+	fn mpmc_branch_from_producer_joined_after_multiple_stages() {
+		let mut builder = build_multi_producer(64, factory(), BusySpin);
 
-		// A depends on producer.
-		let (mut ep_a, mut builder) = builder.event_poller();
-		let a_cursor = ep_a.cursor();
+		// J depends on producer (out-of-band).
+		let mut ep_j = builder.branch_poller();
 
-		// B is a branch that depends on A (out-of-band).
-		let mut ep_b = builder.branch_poller(a_cursor.clone());
+		// R1 depends on producer.
+		let (mut ep_r1, builder) = builder.event_poller();
 
-		// C depends on A via and_then (main chain).
+		// ME depends on R1.
 		let builder = builder.and_then();
-		let (mut ep_c, builder) = builder.event_poller();
+		let (mut ep_me, builder) = builder.event_poller();
 
-		// D joins C and B.
-		let builder = builder.and_then_joining(vec![ep_b.cursor()]);
-		let (mut ep_d, builder) = builder.event_poller();
+		// R2 depends on ME.
+		let builder = builder.and_then();
+		let (mut ep_r2, builder) = builder.event_poller();
+
+		// Report joins R2 and J.
+		let builder = builder.and_then_joining(vec![ep_j.cursor()]);
+		let (mut ep_report, builder) = builder.event_poller();
 
 		let mut producer1 = builder.build();
 		let mut producer2 = producer1.clone();
@@ -1096,59 +1114,55 @@ mod tests {
 
 		let expected = HashSet::from([1, 2]);
 
-		// B, C, D are blocked until A advances.
-		assert_eq!(ep_b.poll().err(), Some(Polling::NoEvents));
-		assert_eq!(ep_c.poll().err(), Some(Polling::NoEvents));
-		assert_eq!(ep_d.poll().err(), Some(Polling::NoEvents));
+		// Downstream stages are blocked until upstream stages advance.
+		assert_eq!(ep_me.poll().err(), Some(Polling::NoEvents));
+		assert_eq!(ep_r2.poll().err(), Some(Polling::NoEvents));
+		assert_eq!(ep_report.poll().err(), Some(Polling::NoEvents));
 
-		// A sees events first.
+		// J is independent of R1/ME/R2.
 		{
-			let mut guard = ep_a.poll().unwrap();
+			let mut guard = ep_j.poll().unwrap();
 			assert_eq!(expected, guard.map(|e| e.num).collect::<HashSet<_>>());
 		}
+		// Still blocked because R2 hasn't advanced.
+		assert_eq!(ep_report.poll().err(), Some(Polling::NoEvents));
 
-		// B can proceed after A, but D is still blocked by C.
+		// Progress the main pipeline.
 		{
-			let mut guard = ep_b.poll().unwrap();
-			assert_eq!(expected, guard.map(|e| e.num).collect::<HashSet<_>>());
-		}
-		assert_eq!(ep_d.poll().err(), Some(Polling::NoEvents));
-
-		// C can proceed after A. Now D can proceed after both B and C.
-		{
-			let mut guard = ep_c.poll().unwrap();
+			let mut guard = ep_r1.poll().unwrap();
 			assert_eq!(expected, guard.map(|e| e.num).collect::<HashSet<_>>());
 		}
 		{
-			let mut guard = ep_d.poll().unwrap();
+			let mut guard = ep_me.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<HashSet<_>>());
+		}
+		{
+			let mut guard = ep_r2.poll().unwrap();
 			assert_eq!(expected, guard.map(|e| e.num).collect::<HashSet<_>>());
 		}
 
-		// All pollers see shutdown after draining.
-		assert_eq!(ep_a.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_b.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_c.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_d.poll().err(), Some(Polling::Shutdown));
+		// Now report can proceed after both R2 and J.
+		{
+			let mut guard = ep_report.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<HashSet<_>>());
+		}
+
+		assert_eq!(ep_j.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_r1.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_me.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_r2.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_report.poll().err(), Some(Polling::Shutdown));
 	}
 
 	#[test]
-	fn spsc_diamond_back_pressure_through_branch_poller() {
-		let builder = build_single_producer(4, factory(), BusySpin);
+	fn spsc_back_pressure_through_out_of_band_branch_poller() {
+		let mut builder = build_single_producer(4, factory(), BusySpin);
+
+		// J depends on producer (out-of-band).
+		let mut ep_j = builder.branch_poller();
 
 		// A depends on producer.
-		let (mut ep_a, mut builder) = builder.event_poller();
-		let a_cursor = ep_a.cursor();
-
-		// B is a branch that depends on A (out-of-band).
-		let mut ep_b = builder.branch_poller(a_cursor);
-
-		// C depends on A via and_then (main chain).
-		let builder = builder.and_then();
-		let (mut ep_c, builder) = builder.event_poller();
-
-		// D joins C and B.
-		let builder = builder.and_then_joining(vec![ep_b.cursor()]);
-		let (mut ep_d, builder) = builder.event_poller();
+		let (mut ep_a, builder) = builder.event_poller();
 
 		let mut producer = builder.build();
 
@@ -1160,30 +1174,17 @@ mod tests {
 		// Buffer full: no consumers have advanced yet.
 		assert_eq!(RingBufferFull, producer.try_publish(|e| e.num = 99).err().unwrap());
 
-		// Poll A → advances to sequence 3. B, C, D are still blocked.
+		// Poll A → advances to sequence 3, but J is still at -1.
 		{
 			let mut g = ep_a.poll().unwrap();
 			assert_eq!(vec![0, 1, 2, 3], g.map(|e| e.num).collect::<Vec<_>>());
 		}
-		// Still full because D can't advance yet (blocked by B and C).
+		// Still full because J is part of producer back-pressure.
 		assert_eq!(RingBufferFull, producer.try_publish(|e| e.num = 99).err().unwrap());
 
-		// Poll C → advances to 3. B still hasn't consumed, so D is still blocked.
+		// Poll J → advances to 3. Producer can now reclaim slots.
 		{
-			let mut g = ep_c.poll().unwrap();
-			assert_eq!(vec![0, 1, 2, 3], g.map(|e| e.num).collect::<Vec<_>>());
-		}
-		assert_eq!(RingBufferFull, producer.try_publish(|e| e.num = 99).err().unwrap());
-
-		// Poll B → advances to 3. Now D is unblocked.
-		{
-			let mut g = ep_b.poll().unwrap();
-			assert_eq!(vec![0, 1, 2, 3], g.map(|e| e.num).collect::<Vec<_>>());
-		}
-
-		// Poll D → advances to 3. Producer can now reclaim slots.
-		{
-			let mut g = ep_d.poll().unwrap();
+			let mut g = ep_j.poll().unwrap();
 			assert_eq!(vec![0, 1, 2, 3], g.map(|e| e.num).collect::<Vec<_>>());
 		}
 
@@ -1199,43 +1200,29 @@ mod tests {
 			assert_eq!(vec![100], g.map(|e| e.num).collect::<Vec<_>>());
 		}
 		{
-			let mut g = ep_b.poll().unwrap();
-			assert_eq!(vec![100], g.map(|e| e.num).collect::<Vec<_>>());
-		}
-		{
-			let mut g = ep_c.poll().unwrap();
-			assert_eq!(vec![100], g.map(|e| e.num).collect::<Vec<_>>());
-		}
-		{
-			let mut g = ep_d.poll().unwrap();
+			let mut g = ep_j.poll().unwrap();
 			assert_eq!(vec![100], g.map(|e| e.num).collect::<Vec<_>>());
 		}
 
 		assert_eq!(ep_a.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_b.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_c.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_d.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_j.poll().err(), Some(Polling::Shutdown));
 	}
 
 	#[test]
 	fn spsc_triple_branch_fan_out_and_join() {
-		let builder = build_single_producer(8, factory(), BusySpin);
+		let mut builder = build_single_producer(8, factory(), BusySpin);
+
+		// Branch out from the producer.
+		let mut ep_j1 = builder.branch_poller();
+		let mut ep_j2 = builder.branch_poller();
+		let mut ep_j3 = builder.branch_poller();
 
 		// A depends on producer.
-		let (mut ep_a, mut builder) = builder.event_poller();
-		let a_cursor = ep_a.cursor();
+		let (mut ep_a, builder) = builder.event_poller();
 
-		// B and C are branches that depend on A.
-		let mut ep_b = builder.branch_poller(Arc::clone(&a_cursor));
-		let mut ep_c = builder.branch_poller(a_cursor);
-
-		// D depends on A via and_then (main chain).
-		let builder = builder.and_then();
-		let (mut ep_d, builder) = builder.event_poller();
-
-		// E joins D, B, and C.
-		let builder = builder.and_then_joining(vec![ep_b.cursor(), ep_c.cursor()]);
-		let (mut ep_e, builder) = builder.event_poller();
+		// Report joins A and J1/J2/J3.
+		let builder = builder.and_then_joining(vec![ep_j1.cursor(), ep_j2.cursor(), ep_j3.cursor()]);
+		let (mut ep_report, builder) = builder.event_poller();
 
 		let mut producer = builder.build();
 
@@ -1247,44 +1234,37 @@ mod tests {
 
 		let expected = vec![1, 2, 3];
 
-		// Downstream pollers blocked until A advances.
-		assert_eq!(ep_b.poll().err(), Some(Polling::NoEvents));
-		assert_eq!(ep_c.poll().err(), Some(Polling::NoEvents));
-		assert_eq!(ep_d.poll().err(), Some(Polling::NoEvents));
-		assert_eq!(ep_e.poll().err(), Some(Polling::NoEvents));
+		// Report is blocked until A and all branches advance.
+		assert_eq!(ep_report.poll().err(), Some(Polling::NoEvents));
 
-		// A sees events first.
 		{
 			let mut g = ep_a.poll().unwrap();
 			assert_eq!(expected, g.map(|e| e.num).collect::<Vec<_>>());
 		}
-
-		// Consume D + one branch: E still blocked.
 		{
-			let mut g = ep_d.poll().unwrap();
+			let mut g = ep_j1.poll().unwrap();
 			assert_eq!(expected, g.map(|e| e.num).collect::<Vec<_>>());
 		}
 		{
-			let mut g = ep_b.poll().unwrap();
+			let mut g = ep_j2.poll().unwrap();
 			assert_eq!(expected, g.map(|e| e.num).collect::<Vec<_>>());
 		}
-		assert_eq!(ep_e.poll().err(), Some(Polling::NoEvents));
-
-		// Consume last branch: E unblocks.
+		// Still blocked on J3.
+		assert_eq!(ep_report.poll().err(), Some(Polling::NoEvents));
 		{
-			let mut g = ep_c.poll().unwrap();
+			let mut g = ep_j3.poll().unwrap();
 			assert_eq!(expected, g.map(|e| e.num).collect::<Vec<_>>());
 		}
 		{
-			let mut g = ep_e.poll().unwrap();
+			let mut g = ep_report.poll().unwrap();
 			assert_eq!(expected, g.map(|e| e.num).collect::<Vec<_>>());
 		}
 
 		assert_eq!(ep_a.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_b.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_c.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_d.poll().err(), Some(Polling::Shutdown));
-		assert_eq!(ep_e.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_j1.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_j2.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_j3.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_report.poll().err(), Some(Polling::Shutdown));
 	}
 
 	#[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,6 +335,14 @@ mod tests {
 		|| Event { num: -1 }
 	}
 
+	struct UnblockOnDrop(Arc<AtomicBool>);
+
+	impl Drop for UnblockOnDrop {
+		fn drop(&mut self) {
+			self.0.store(true, Relaxed);
+		}
+	}
+
 	#[test]
 	#[should_panic(expected = "Size must be power of 2.")]
 	fn size_not_a_factor_of_2() {
@@ -1045,6 +1053,180 @@ mod tests {
 		}
 
 		assert_eq!(ep_j.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_r1.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_me.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_r2.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_report.poll().err(), Some(Polling::Shutdown));
+	}
+
+	#[test]
+	fn spsc_branch_processor_joined_after_multiple_stages() {
+		let mut builder = build_single_producer(8, factory(), BusySpin);
+
+		let allow_b     = Arc::new(AtomicBool::new(false));
+		let b_started   = Arc::new(AtomicBool::new(false));
+		let b_processed = Arc::new(AtomicBool::new(false));
+
+		let b_join = {
+			let allow_b     = Arc::clone(&allow_b);
+			let b_started   = Arc::clone(&b_started);
+			let b_processed = Arc::clone(&b_processed);
+			builder.branch_handle_events_with(move |_e: &Event, _, _| {
+				b_started.store(true, Relaxed);
+				while !allow_b.load(Relaxed) { std::hint::spin_loop(); }
+				b_processed.store(true, Relaxed);
+			})
+		};
+
+		// R1 depends on producer.
+		let (mut ep_r1, builder) = builder.event_poller();
+
+		// ME depends on R1.
+		let builder = builder.and_then();
+		let (mut ep_me, builder) = builder.event_poller();
+
+		// R2 depends on ME.
+		let builder = builder.and_then();
+		let (mut ep_r2, builder) = builder.event_poller();
+
+		// Report joins R2 and B.
+		let builder = builder.and_then_joining(vec![b_join.into()]);
+		let (mut ep_report, builder) = builder.event_poller();
+
+		let mut producer = builder.build();
+		let _unblock = UnblockOnDrop(Arc::clone(&allow_b));
+
+		producer.publish(|e| { e.num = 1; });
+
+		let expected = vec![1];
+
+		// Progress the main pipeline.
+		{
+			let mut guard = ep_r1.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut guard = ep_me.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut guard = ep_r2.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		// Wait until B has started processing (and is blocked).
+		for _ in 0..1_000_000 {
+			if b_started.load(Relaxed) { break; }
+			std::hint::spin_loop();
+		}
+		assert!(b_started.load(Relaxed), "branch processor should start");
+
+		// Report is blocked on B.
+		assert_eq!(ep_report.poll().err(), Some(Polling::NoEvents));
+
+		// Unblock B and wait for it to finish.
+		allow_b.store(true, Relaxed);
+		for _ in 0..1_000_000 {
+			if b_processed.load(Relaxed) { break; }
+			std::hint::spin_loop();
+		}
+		assert!(b_processed.load(Relaxed), "branch processor should finish");
+
+		// Now report can proceed after both R2 and B.
+		{
+			let mut guard = ep_report.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		drop(producer);
+
+		assert_eq!(ep_r1.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_me.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_r2.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_report.poll().err(), Some(Polling::Shutdown));
+	}
+
+	#[test]
+	fn mpmc_branch_processor_joined_after_multiple_stages() {
+		let mut builder = build_multi_producer(64, factory(), BusySpin);
+
+		let allow_b     = Arc::new(AtomicBool::new(false));
+		let b_started   = Arc::new(AtomicBool::new(false));
+		let b_processed = Arc::new(AtomicBool::new(false));
+
+		let b_join = {
+			let allow_b     = Arc::clone(&allow_b);
+			let b_started   = Arc::clone(&b_started);
+			let b_processed = Arc::clone(&b_processed);
+			builder.branch_handle_events_with(move |_e: &Event, _, _| {
+				b_started.store(true, Relaxed);
+				while !allow_b.load(Relaxed) { std::hint::spin_loop(); }
+				b_processed.store(true, Relaxed);
+			})
+		};
+
+		// R1 depends on producer.
+		let (mut ep_r1, builder) = builder.event_poller();
+
+		// ME depends on R1.
+		let builder = builder.and_then();
+		let (mut ep_me, builder) = builder.event_poller();
+
+		// R2 depends on ME.
+		let builder = builder.and_then();
+		let (mut ep_r2, builder) = builder.event_poller();
+
+		// Report joins R2 and B.
+		let builder = builder.and_then_joining(vec![b_join.into()]);
+		let (mut ep_report, builder) = builder.event_poller();
+
+		let mut producer = builder.build();
+		let _unblock = UnblockOnDrop(Arc::clone(&allow_b));
+
+		producer.publish(|e| { e.num = 1; });
+
+		let expected = vec![1];
+
+		// Progress the main pipeline.
+		{
+			let mut guard = ep_r1.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut guard = ep_me.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut guard = ep_r2.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		// Wait until B has started processing (and is blocked).
+		for _ in 0..1_000_000 {
+			if b_started.load(Relaxed) { break; }
+			std::hint::spin_loop();
+		}
+		assert!(b_started.load(Relaxed), "branch processor should start");
+
+		// Report is blocked on B.
+		assert_eq!(ep_report.poll().err(), Some(Polling::NoEvents));
+
+		// Unblock B and wait for it to finish.
+		allow_b.store(true, Relaxed);
+		for _ in 0..1_000_000 {
+			if b_processed.load(Relaxed) { break; }
+			std::hint::spin_loop();
+		}
+		assert!(b_processed.load(Relaxed), "branch processor should finish");
+
+		// Now report can proceed after both R2 and B.
+		{
+			let mut guard = ep_report.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		drop(producer);
+
 		assert_eq!(ep_r1.poll().err(), Some(Polling::Shutdown));
 		assert_eq!(ep_me.poll().err(), Some(Polling::Shutdown));
 		assert_eq!(ep_r2.poll().err(), Some(Polling::Shutdown));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,21 @@
 //!     }
 //! }
 //! ```
+//!
+//! ### Diamond / DAG Topology
+//!
+//! You can build diamond/DAG topologies by creating a branch [`EventPoller`] that depends on an
+//! earlier consumer and then joining it into a downstream barrier:
+//!
+//! ```text
+//! Producer -> A -> [B (branch) || C] -> D (joins B + C)
+//! ```
+//!
+//! Use [`SPBuilder::branch_poller`](builder::single::SPBuilder::branch_poller) /
+//! [`MPBuilder::branch_poller`](builder::multi::MPBuilder::branch_poller) to create a branch poller,
+//! and [`SPBuilder::and_then_joining`](builder::single::SPBuilder::and_then_joining) /
+//! [`MPBuilder::and_then_joining`](builder::multi::MPBuilder::and_then_joining) to join it into the
+//! downstream dependency chain.
 
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
@@ -953,6 +968,323 @@ mod tests {
 		assert_eq!(ep1.poll().err(), Some(Polling::Shutdown));
 		assert_eq!(ep2.poll().err(), Some(Polling::Shutdown));
 		assert_eq!(ep3.poll().err(), Some(Polling::Shutdown));
+	}
+
+	#[test]
+	fn spsc_diamond_topology_with_event_pollers() {
+		let builder = build_single_producer(8, factory(), BusySpin);
+
+		// A depends on producer.
+		let (mut ep_a, mut builder) = builder.event_poller();
+		let a_cursor = ep_a.cursor();
+
+		// B is a branch that depends on A (out-of-band).
+		let mut ep_b = builder.branch_poller(a_cursor.clone());
+
+		// C depends on A via and_then (main chain).
+		let builder = builder.and_then();
+		let (mut ep_c, builder) = builder.event_poller();
+
+		// D joins C and B.
+		let builder = builder.and_then_joining(vec![ep_b.cursor()]);
+		let (mut ep_d, builder) = builder.event_poller();
+
+		let mut producer = builder.build();
+
+		// Publish three events.
+		producer.publish(|e| { e.num = 10; });
+		producer.publish(|e| { e.num = 20; });
+		producer.publish(|e| { e.num = 30; });
+		drop(producer);
+
+		let expected = vec![10, 20, 30];
+
+		// B, C, D are blocked until A advances.
+		assert_eq!(ep_b.poll().err(), Some(Polling::NoEvents));
+		assert_eq!(ep_c.poll().err(), Some(Polling::NoEvents));
+		assert_eq!(ep_d.poll().err(), Some(Polling::NoEvents));
+
+		// A sees events first.
+		{
+			let mut guard = ep_a.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		// B can proceed after A, but D is still blocked by C.
+		{
+			let mut guard = ep_b.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+		assert_eq!(ep_d.poll().err(), Some(Polling::NoEvents));
+
+		// C can proceed after A. Now D can proceed after both B and C.
+		{
+			let mut guard = ep_c.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut guard = ep_d.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		// All pollers see shutdown after draining.
+		assert_eq!(ep_a.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_b.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_c.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_d.poll().err(), Some(Polling::Shutdown));
+	}
+
+	#[test]
+	fn spsc_and_then_joining_with_empty_extra_cursors() {
+		let builder = build_single_producer(8, factory(), BusySpin);
+
+		// A depends on producer.
+		let (mut ep_a, builder) = builder.event_poller();
+		// B depends on A via and_then_joining(vec![]) which should degrade to and_then().
+		let builder = builder.and_then_joining(vec![]);
+		let (mut ep_b, builder) = builder.event_poller();
+
+		let mut producer = builder.build();
+		producer.publish(|e| { e.num = 1; });
+		producer.publish(|e| { e.num = 2; });
+		drop(producer);
+
+		// B is blocked until A advances.
+		assert_eq!(ep_b.poll().err(), Some(Polling::NoEvents));
+
+		let expected = vec![1, 2];
+		{
+			let mut g = ep_a.poll().unwrap();
+			assert_eq!(expected, g.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut g = ep_b.poll().unwrap();
+			assert_eq!(expected, g.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		assert_eq!(ep_a.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_b.poll().err(), Some(Polling::Shutdown));
+	}
+
+	#[test]
+	fn mpmc_diamond_topology_with_event_pollers() {
+		let builder = build_multi_producer(64, factory(), BusySpin);
+
+		// A depends on producer.
+		let (mut ep_a, mut builder) = builder.event_poller();
+		let a_cursor = ep_a.cursor();
+
+		// B is a branch that depends on A (out-of-band).
+		let mut ep_b = builder.branch_poller(a_cursor.clone());
+
+		// C depends on A via and_then (main chain).
+		let builder = builder.and_then();
+		let (mut ep_c, builder) = builder.event_poller();
+
+		// D joins C and B.
+		let builder = builder.and_then_joining(vec![ep_b.cursor()]);
+		let (mut ep_d, builder) = builder.event_poller();
+
+		let mut producer1 = builder.build();
+		let mut producer2 = producer1.clone();
+
+		// Publish two events.
+		producer1.publish(|e| { e.num = 1; });
+		producer2.publish(|e| { e.num = 2; });
+		drop(producer1);
+		drop(producer2);
+
+		let expected = HashSet::from([1, 2]);
+
+		// B, C, D are blocked until A advances.
+		assert_eq!(ep_b.poll().err(), Some(Polling::NoEvents));
+		assert_eq!(ep_c.poll().err(), Some(Polling::NoEvents));
+		assert_eq!(ep_d.poll().err(), Some(Polling::NoEvents));
+
+		// A sees events first.
+		{
+			let mut guard = ep_a.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<HashSet<_>>());
+		}
+
+		// B can proceed after A, but D is still blocked by C.
+		{
+			let mut guard = ep_b.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<HashSet<_>>());
+		}
+		assert_eq!(ep_d.poll().err(), Some(Polling::NoEvents));
+
+		// C can proceed after A. Now D can proceed after both B and C.
+		{
+			let mut guard = ep_c.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<HashSet<_>>());
+		}
+		{
+			let mut guard = ep_d.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<HashSet<_>>());
+		}
+
+		// All pollers see shutdown after draining.
+		assert_eq!(ep_a.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_b.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_c.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_d.poll().err(), Some(Polling::Shutdown));
+	}
+
+	#[test]
+	fn spsc_diamond_back_pressure_through_branch_poller() {
+		let builder = build_single_producer(4, factory(), BusySpin);
+
+		// A depends on producer.
+		let (mut ep_a, mut builder) = builder.event_poller();
+		let a_cursor = ep_a.cursor();
+
+		// B is a branch that depends on A (out-of-band).
+		let mut ep_b = builder.branch_poller(a_cursor);
+
+		// C depends on A via and_then (main chain).
+		let builder = builder.and_then();
+		let (mut ep_c, builder) = builder.event_poller();
+
+		// D joins C and B.
+		let builder = builder.and_then_joining(vec![ep_b.cursor()]);
+		let (mut ep_d, builder) = builder.event_poller();
+
+		let mut producer = builder.build();
+
+		// Fill the ring buffer (size 4).
+		for i in 0..4 {
+			producer.try_publish(|e| e.num = i).expect("Should publish");
+		}
+
+		// Buffer full: no consumers have advanced yet.
+		assert_eq!(RingBufferFull, producer.try_publish(|e| e.num = 99).err().unwrap());
+
+		// Poll A → advances to sequence 3. B, C, D are still blocked.
+		{
+			let mut g = ep_a.poll().unwrap();
+			assert_eq!(vec![0, 1, 2, 3], g.map(|e| e.num).collect::<Vec<_>>());
+		}
+		// Still full because D can't advance yet (blocked by B and C).
+		assert_eq!(RingBufferFull, producer.try_publish(|e| e.num = 99).err().unwrap());
+
+		// Poll C → advances to 3. B still hasn't consumed, so D is still blocked.
+		{
+			let mut g = ep_c.poll().unwrap();
+			assert_eq!(vec![0, 1, 2, 3], g.map(|e| e.num).collect::<Vec<_>>());
+		}
+		assert_eq!(RingBufferFull, producer.try_publish(|e| e.num = 99).err().unwrap());
+
+		// Poll B → advances to 3. Now D is unblocked.
+		{
+			let mut g = ep_b.poll().unwrap();
+			assert_eq!(vec![0, 1, 2, 3], g.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		// Poll D → advances to 3. Producer can now reclaim slots.
+		{
+			let mut g = ep_d.poll().unwrap();
+			assert_eq!(vec![0, 1, 2, 3], g.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		// Now the 5th publish succeeds.
+		producer.try_publish(|e| e.num = 100).expect("Should publish after all consumers advanced");
+
+		// Shutdown.
+		drop(producer);
+
+		// Drain the remaining event(s) before asserting shutdown.
+		{
+			let mut g = ep_a.poll().unwrap();
+			assert_eq!(vec![100], g.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut g = ep_b.poll().unwrap();
+			assert_eq!(vec![100], g.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut g = ep_c.poll().unwrap();
+			assert_eq!(vec![100], g.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut g = ep_d.poll().unwrap();
+			assert_eq!(vec![100], g.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		assert_eq!(ep_a.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_b.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_c.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_d.poll().err(), Some(Polling::Shutdown));
+	}
+
+	#[test]
+	fn spsc_triple_branch_fan_out_and_join() {
+		let builder = build_single_producer(8, factory(), BusySpin);
+
+		// A depends on producer.
+		let (mut ep_a, mut builder) = builder.event_poller();
+		let a_cursor = ep_a.cursor();
+
+		// B and C are branches that depend on A.
+		let mut ep_b = builder.branch_poller(Arc::clone(&a_cursor));
+		let mut ep_c = builder.branch_poller(a_cursor);
+
+		// D depends on A via and_then (main chain).
+		let builder = builder.and_then();
+		let (mut ep_d, builder) = builder.event_poller();
+
+		// E joins D, B, and C.
+		let builder = builder.and_then_joining(vec![ep_b.cursor(), ep_c.cursor()]);
+		let (mut ep_e, builder) = builder.event_poller();
+
+		let mut producer = builder.build();
+
+		// Publish 3 events.
+		for i in 1..=3 {
+			producer.publish(|e| { e.num = i; });
+		}
+		drop(producer);
+
+		let expected = vec![1, 2, 3];
+
+		// Downstream pollers blocked until A advances.
+		assert_eq!(ep_b.poll().err(), Some(Polling::NoEvents));
+		assert_eq!(ep_c.poll().err(), Some(Polling::NoEvents));
+		assert_eq!(ep_d.poll().err(), Some(Polling::NoEvents));
+		assert_eq!(ep_e.poll().err(), Some(Polling::NoEvents));
+
+		// A sees events first.
+		{
+			let mut g = ep_a.poll().unwrap();
+			assert_eq!(expected, g.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		// Consume D + one branch: E still blocked.
+		{
+			let mut g = ep_d.poll().unwrap();
+			assert_eq!(expected, g.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut g = ep_b.poll().unwrap();
+			assert_eq!(expected, g.map(|e| e.num).collect::<Vec<_>>());
+		}
+		assert_eq!(ep_e.poll().err(), Some(Polling::NoEvents));
+
+		// Consume last branch: E unblocks.
+		{
+			let mut g = ep_c.poll().unwrap();
+			assert_eq!(expected, g.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut g = ep_e.poll().unwrap();
+			assert_eq!(expected, g.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		assert_eq!(ep_a.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_b.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_c.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_d.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_e.poll().err(), Some(Polling::Shutdown));
 	}
 
 	#[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,7 @@ mod ringbuffer;
 mod producer;
 
 pub use crate::builder::{build_single_producer, build_multi_producer, ProcessorSettings};
-pub use crate::cursor::Cursor;
+pub use crate::cursor::CursorHandle;
 pub use crate::producer::{Producer, RingBufferFull, MissingFreeSlots};
 pub use crate::wait_strategies::{BusySpin, BusySpinWithSpinLoopHint};
 pub use crate::producer::{single::{SingleProducer, SingleProducerBarrier}, multi::{MultiProducer,  MultiProducerBarrier}};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,7 @@ mod tests {
 	use std::cell::RefCell;
 	use std::collections::HashSet;
 	use std::sync::atomic::AtomicBool;
+	use std::sync::atomic::AtomicI64;
 	use std::sync::atomic::Ordering::Relaxed;
 	use std::sync::{mpsc, Arc};
 	use std::thread;
@@ -1131,6 +1132,89 @@ mod tests {
 			std::hint::spin_loop();
 		}
 		assert!(b_processed.load(Relaxed), "branch processor should finish");
+
+		// Now report can proceed after both R2 and B.
+		{
+			let mut guard = ep_report.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		drop(producer);
+
+		assert_eq!(ep_r1.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_me.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_r2.poll().err(), Some(Polling::Shutdown));
+		assert_eq!(ep_report.poll().err(), Some(Polling::Shutdown));
+	}
+
+	#[test]
+	fn spsc_branch_processor_with_state_joined_after_multiple_stages() {
+		let mut builder = build_single_producer(8, factory(), BusySpin);
+
+		let allow_b     = Arc::new(AtomicBool::new(false));
+		let state_seen  = Arc::new(AtomicI64::new(0));
+		let b_processed = Arc::new(AtomicBool::new(false));
+
+		let b_join = {
+			let allow_b     = Arc::clone(&allow_b);
+			let state_seen  = Arc::clone(&state_seen);
+			let b_processed = Arc::clone(&b_processed);
+			builder.branch_handle_events_and_state_with(
+				move |state: &mut i64, _e: &Event, _, _| {
+					*state += 1;
+					while !allow_b.load(Relaxed) { std::hint::spin_loop(); }
+					state_seen.store(*state, Relaxed);
+					b_processed.store(true, Relaxed);
+				},
+				|| 0_i64
+			)
+		};
+
+		// R1 depends on producer.
+		let (mut ep_r1, builder) = builder.event_poller();
+		// ME depends on R1.
+		let builder = builder.and_then();
+		let (mut ep_me, builder) = builder.event_poller();
+		// R2 depends on ME.
+		let builder = builder.and_then();
+		let (mut ep_r2, builder) = builder.event_poller();
+
+		// Report joins R2 and B.
+		let builder = builder.and_then_joining(vec![b_join.into()]);
+		let (mut ep_report, builder) = builder.event_poller();
+
+		let mut producer = builder.build();
+		let _unblock = UnblockOnDrop(Arc::clone(&allow_b));
+
+		producer.publish(|e| { e.num = 1; });
+
+		let expected = vec![1];
+
+		// Progress the main pipeline.
+		{
+			let mut guard = ep_r1.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut guard = ep_me.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+		{
+			let mut guard = ep_r2.poll().unwrap();
+			assert_eq!(expected, guard.map(|e| e.num).collect::<Vec<_>>());
+		}
+
+		// Report is blocked on B.
+		assert_eq!(ep_report.poll().err(), Some(Polling::NoEvents));
+
+		// Unblock B and wait for it to finish.
+		allow_b.store(true, Relaxed);
+		for _ in 0..1_000_000 {
+			if b_processed.load(Relaxed) { break; }
+			std::hint::spin_loop();
+		}
+		assert!(b_processed.load(Relaxed), "branch processor should finish");
+		assert_eq!(state_seen.load(Relaxed), 1);
 
 		// Now report can proceed after both R2 and B.
 		{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -998,7 +998,7 @@ mod tests {
 		let mut builder = build_single_producer(8, factory(), BusySpin);
 
 		// J depends on producer (out-of-band).
-		let mut ep_j = builder.branch_poller();
+		let (j, mut ep_j) = builder.branch_poller().join_handle();
 
 		// R1 depends on producer.
 		let (mut ep_r1, builder) = builder.event_poller();
@@ -1012,7 +1012,6 @@ mod tests {
 		let (mut ep_r2, builder) = builder.event_poller();
 
 		// Report joins R2 and J.
-		let j = ep_j.join_handle();
 		let builder = builder.and_then_joining(vec![j.into()]);
 		let (mut ep_report, builder) = builder.event_poller();
 
@@ -1360,7 +1359,7 @@ mod tests {
 		let mut builder = build_multi_producer(64, factory(), BusySpin);
 
 		// J depends on producer (out-of-band).
-		let mut ep_j = builder.branch_poller();
+		let (j, mut ep_j) = builder.branch_poller().join_handle();
 
 		// R1 depends on producer.
 		let (mut ep_r1, builder) = builder.event_poller();
@@ -1374,7 +1373,6 @@ mod tests {
 		let (mut ep_r2, builder) = builder.event_poller();
 
 		// Report joins R2 and J.
-		let j = ep_j.join_handle();
 		let builder = builder.and_then_joining(vec![j.into()]);
 		let (mut ep_report, builder) = builder.event_poller();
 
@@ -1434,7 +1432,7 @@ mod tests {
 		let mut builder = build_single_producer(4, factory(), BusySpin);
 
 		// J depends on producer (out-of-band).
-		let mut ep_j = builder.branch_poller();
+		let (_j, mut ep_j) = builder.branch_poller().join_handle();
 
 		// A depends on producer.
 		let (mut ep_a, builder) = builder.event_poller();
@@ -1488,17 +1486,14 @@ mod tests {
 		let mut builder = build_single_producer(8, factory(), BusySpin);
 
 		// Branch out from the producer.
-		let mut ep_j1 = builder.branch_poller();
-		let mut ep_j2 = builder.branch_poller();
-		let mut ep_j3 = builder.branch_poller();
+		let (j1, mut ep_j1) = builder.branch_poller().join_handle();
+		let (j2, mut ep_j2) = builder.branch_poller().join_handle();
+		let (j3, mut ep_j3) = builder.branch_poller().join_handle();
 
 		// A depends on producer.
 		let (mut ep_a, builder) = builder.event_poller();
 
 		// Report joins A and J1/J2/J3.
-		let j1 = ep_j1.join_handle();
-		let j2 = ep_j2.join_handle();
-		let j3 = ep_j3.join_handle();
 		let builder = builder.and_then_joining(vec![j1.into(), j2.into(), j3.into()]);
 		let (mut ep_report, builder) = builder.event_poller();
 

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -4,7 +4,6 @@ use thiserror::Error;
 pub mod single;
 pub mod multi;
 
-use std::sync::{atomic::AtomicI64, Arc};
 use crate::{barrier::Barrier, ringbuffer::RingBuffer, Sequence};
 
 /// Barrier for producers.

--- a/src/producer/multi.rs
+++ b/src/producer/multi.rs
@@ -20,6 +20,7 @@ pub struct MultiProducer<E, C> {
 	shared_producer:             Arc<Mutex<SharedProducer>>,
 	producer_barrier:            Arc<MultiProducerBarrier>,
 	consumer_barrier:            Arc<C>,
+	extra_gating_cursors:        Vec<Arc<Cursor>>,
 	/// Next sequence number for this MultiProducer to publish.
 	claimed_sequence:            Sequence,
 	/// Highest sequence available for publication because the Consumers are "enough" behind
@@ -88,6 +89,7 @@ impl<E, C> Clone for MultiProducer<E, C> {
 		let producer_barrier     = Arc::clone(&self.producer_barrier);
 		let shared_producer      = Arc::clone(&self.shared_producer);
 		let consumer_barrier     = Arc::clone(&self.consumer_barrier);
+		let extra_gating_cursors = self.extra_gating_cursors.iter().map(Arc::clone).collect();
 		let ring_buffer          = Arc::clone(&self.ring_buffer);
 
 		MultiProducer {
@@ -96,6 +98,7 @@ impl<E, C> Clone for MultiProducer<E, C> {
 			shared_producer,
 			producer_barrier,
 			consumer_barrier,
+			extra_gating_cursors,
 			claimed_sequence: NONE,
 			sequence_clear_of_consumers: 0
 		}
@@ -125,6 +128,7 @@ where
 		producer_barrier:     Arc<MultiProducerBarrier>,
 		consumers:            Vec<Consumer>,
 		consumer_barrier:     C,
+		extra_gating_cursors: Vec<Arc<Cursor>>,
 	) -> Self
 	{
 		let shared_producer = Arc::new(
@@ -144,6 +148,7 @@ where
 			shared_producer,
 			producer_barrier,
 			consumer_barrier,
+			extra_gating_cursors,
 			claimed_sequence: NONE,
 			sequence_clear_of_consumers
 		}
@@ -161,7 +166,11 @@ where
 				// We have to check where the rear consumer is in case we're about to
 				// publish into the slot currently being read by the slowest consumer.
 				// (Consumer is too far behind the producer to publish next n events).
-				let rear_sequence_read = self.consumer_barrier.get_after(current);
+				let mut rear_sequence_read = self.consumer_barrier.get_after(current);
+				for cursor in &self.extra_gating_cursors {
+					let sequence = cursor.relaxed_value();
+					rear_sequence_read = std::cmp::min(rear_sequence_read, sequence);
+				}
 				let free_slots         = self.ring_buffer.free_slots(current, rear_sequence_read);
 				if free_slots < n {
 					return Err(MissingFreeSlots((n - free_slots) as u64));

--- a/src/producer/single.rs
+++ b/src/producer/single.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{fence, Ordering};
 use crate::{barrier::{Barrier, NONE}, cursor::Cursor, producer::ProducerBarrier};
 use crossbeam_utils::CachePadded;
 use crate::{consumer::Consumer, ringbuffer::RingBuffer, Sequence};
+use std::sync::{Arc, atomic::AtomicI64};
 use super::*;
 
 /// Producer for publishing to the Disruptor from a single thread.
@@ -14,6 +15,7 @@ pub struct SingleProducer<E, C> {
 	producer_barrier:            Arc<SingleProducerBarrier>,
 	consumers:                   Vec<Consumer>,
 	consumer_barrier:            C,
+	extra_gating_cursors:        Vec<Arc<Cursor>>,
 	/// Next sequence to be published.
 	sequence:                    Sequence,
 	/// Highest sequence available for publication because the Consumers are "enough" behind
@@ -76,6 +78,7 @@ where
 		producer_barrier:     Arc<SingleProducerBarrier>,
 		consumers:            Vec<Consumer>,
 		consumer_barrier:     C,
+		extra_gating_cursors: Vec<Arc<Cursor>>,
 	) -> Self
 	{
 		let sequence_clear_of_consumers = ring_buffer.size() - 1;
@@ -85,6 +88,7 @@ where
 			producer_barrier,
 			consumers,
 			consumer_barrier,
+			extra_gating_cursors,
 			sequence: 0,
 			sequence_clear_of_consumers,
 		}
@@ -100,7 +104,11 @@ where
 			// which is still being read.
 			// (The slowest consumer is too far behind the producer to publish next n events).
 			let last_published     = self.sequence - 1;
-			let rear_sequence_read = self.consumer_barrier.get_after(last_published);
+			let mut rear_sequence_read = self.consumer_barrier.get_after(last_published);
+			for cursor in &self.extra_gating_cursors {
+				let sequence = cursor.relaxed_value();
+				rear_sequence_read = std::cmp::min(rear_sequence_read, sequence);
+			}
 			let free_slots         = self.ring_buffer.free_slots(last_published, rear_sequence_read);
 			if free_slots < n {
 				return Err(MissingFreeSlots((n - free_slots) as u64));


### PR DESCRIPTION
This PR adds “diamond / DAG topology” support for the EventPoller API, so downstream consumers can depend on (join) multiple independent branches before advancing.

I’m using disruptor-rs as the core coordination primitive for a low-latency, multi-stage pipeline. The library’s existing builder API makes it easy to express a linear dependency chain (A → B → C) and to mix “managed thread” consumers with the EventPoller API. However, in real systems you often need a diamond/DAG topology where one stage fans out into multiple independent branches and a downstream stage must wait for all branches:

`Producer -> A -> [B (branch) || C (main chain)] -> D (join)`

Concrete examples of this pattern:

- A “side-effect” branch (e.g., persistence / journaling / metrics) that should run in parallel with the main processing path.
- A downstream stage that must not observe an event as “complete” until both the main chain and the side-effect branch have advanced (join semantics).
- Back-pressure that accounts for all branches so producers don’t reclaim ring slots while any branch could still read them.