### PR TITLE
feat: add free_slots() on SingleProducer and MultiProducer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1408,4 +1408,55 @@ mod tests {
 			assert_eq!(seq_seen_by_pid, seen_sequences[seq_seen_by_pid as usize]);
 		}
 	}
+
+	#[test]
+	fn spsc_free_slots() {
+		let barrier   = Arc::new(AtomicBool::new(true));
+		let processor = {
+			let barrier = Arc::clone(&barrier);
+			move |_: &Event, _, _| {
+				while barrier.load(Relaxed) { /* Wait. */ }
+			}
+		};
+		let mut producer = build_single_producer(8, factory(), BusySpinWithSpinLoopHint)
+			.handle_events_with(processor)
+			.build();
+
+		assert_eq!(producer.free_slots(), 8);
+
+		producer.try_publish(|e| e.num = 1).expect("Should publish");
+		producer.try_publish(|e| e.num = 2).expect("Should publish");
+		producer.try_publish(|e| e.num = 3).expect("Should publish");
+
+		// 3 published, consumer blocked, ring buffer is 8, so 5 free.
+		assert_eq!(producer.free_slots(), 5);
+
+		barrier.store(false, Relaxed);
+		drop(producer);
+	}
+
+	#[test]
+	fn mpsc_free_slots() {
+		let barrier   = Arc::new(AtomicBool::new(true));
+		let processor = {
+			let barrier = Arc::clone(&barrier);
+			move |_: &Event, _, _| {
+				while barrier.load(Relaxed) { /* Wait. */ }
+			}
+		};
+		let mut producer = build_multi_producer(64, factory(), BusySpinWithSpinLoopHint)
+			.handle_events_with(processor)
+			.build();
+
+		assert_eq!(producer.free_slots(), 64);
+
+		producer.try_publish(|e| e.num = 1).expect("Should publish");
+		producer.try_publish(|e| e.num = 2).expect("Should publish");
+
+		// 2 published, consumer blocked, ring buffer is 64, so 62 free.
+		assert_eq!(producer.free_slots(), 62);
+
+		barrier.store(false, Relaxed);
+		drop(producer);
+	}
 }

--- a/src/producer/multi.rs
+++ b/src/producer/multi.rs
@@ -119,6 +119,17 @@ impl<E, C> MultiProducer<E, C>
 where
 	C: Barrier
 {
+	/// Returns the number of free slots in the ring buffer.
+	///
+	/// Across multiple producers this is a best-effort snapshot: another
+	/// producer may claim slots between reading the value and using it.
+	#[inline]
+	pub fn free_slots(&self) -> usize {
+		let current            = self.producer_barrier.current();
+		let rear_sequence_read = self.consumer_barrier.get_after(current);
+		self.ring_buffer.free_slots(current, rear_sequence_read) as usize
+	}
+
 	pub(crate) fn new(
 		shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
 		ring_buffer:          Arc<RingBuffer<E>>,

--- a/src/producer/single.rs
+++ b/src/producer/single.rs
@@ -71,6 +71,14 @@ impl<E, C> SingleProducer<E, C>
 where
 	C: Barrier
 {
+	/// Returns the number of free slots in the ring buffer.
+	#[inline]
+	pub fn free_slots(&self) -> usize {
+		let last_published     = self.sequence - 1;
+		let rear_sequence_read = self.consumer_barrier.get_after(last_published);
+		self.ring_buffer.free_slots(last_published, rear_sequence_read) as usize
+	}
+
 	pub(crate) fn new(
 		shutdown_at_sequence: Arc<CachePadded<AtomicI64>>,
 		ring_buffer:          Arc<RingBuffer<E>>,


### PR DESCRIPTION
Follow-up to #35, much smaller this time.

Adds a public `free_slots()` inherent method on `SingleProducer` and `MultiProducer`. The computation reuses `RingBuffer::free_slots()` the same way as the existing slow-path check in `next_sequences()`, just without the mutation.

Use case: back-pressure monitoring in a Rust market data pipeline I'm building on top of `disruptor-rs`, mirroring `remainingCapacity()` on the Java LMAX disruptor.

Two new tests verify the transitions: 8 free → publish 3 → 5 free on the SPSC producer, and 64 free → publish 2 → 62 free on the MPSC producer. `cargo test --lib` passes (35/35) and `cargo doc --no-deps` is clean.