### PR TITLE
panic on sched_setaffinity failure

### DIFF
--- a/src/affinity.rs
+++ b/src/affinity.rs
@@ -1,20 +1,25 @@
 use core_affinity::CoreId;
 
 pub(crate) fn cpu_has_core_else_panic(id: usize) {
-	let available: Vec<usize> = core_affinity::get_core_ids().unwrap().iter()
-		.map(|core_id| core_id.id)
-		.collect();
+    let available: Vec<usize> = core_affinity::get_core_ids()
+        .unwrap()
+        .iter()
+        .map(|core_id| core_id.id)
+        .collect();
 
-	if !available.contains(&id) {
-		panic!("No core with ID={} is available.", id);
-	}
+    if !available.contains(&id) {
+        panic!("No core with ID={} is available.", id);
+    }
 }
 
 pub(crate) fn set_affinity_if_defined(core_affinity: Option<CoreId>, thread_name: &str) {
-	if let Some(core_id) = core_affinity {
-		let got_pinned = core_affinity::set_for_current(core_id);
-		if !got_pinned {
-			eprintln!("Could not pin processor thread '{}' to {:?}.", thread_name, core_id);
-		}
-	}
+    if let Some(core_id) = core_affinity {
+        let got_pinned = core_affinity::set_for_current(core_id);
+        if !got_pinned {
+            eprintln!(
+                "Could not pin processor thread '{}' to {:?}.",
+                thread_name, core_id
+            );
+        }
+    }
 }

--- a/src/affinity.rs
+++ b/src/affinity.rs
@@ -13,10 +13,11 @@ pub(crate) fn cpu_has_core_else_panic(id: usize) {
 }
 
 pub(crate) fn set_affinity_if_defined(core_affinity: Option<CoreId>, thread_name: &str) {
+    #[cfg(not(target_os = "macos"))]
     if let Some(core_id) = core_affinity {
         let got_pinned = core_affinity::set_for_current(core_id);
         if !got_pinned {
-            eprintln!(
+            panic!(
                 "Could not pin processor thread '{}' to {:?}.",
                 thread_name, core_id
             );

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -137,7 +137,7 @@ pub trait ProcessorSettings<E, W>: Sized {
 	fn shared(&mut self) -> &mut Shared<E, W>;
 
 	/// Pin processor thread on the core with `id` for the next added event handler.
-	/// Outputs an error on stderr if the thread could not be pinned.
+	/// No-op on macos. Panics if the thread could not be pinned.
 	fn pin_at_core(mut self, id: usize) -> Self {
 		self.shared().pin_at_core(id);
 		self


### PR DESCRIPTION
closes #37 
no LLMs have been used. 
tested on macos and Linux.