### PR TITLE
Let builder produce multiple pollers at once

### DIFF
--- a/src/builder/multi.rs
+++ b/src/builder/multi.rs
@@ -70,6 +70,16 @@ where
 		}
 	}
 
+	/// Force builder transition to multi consumer state. This is useful if you want to add multiple consumers in a loop.
+	pub fn with_multi_consumer(self) -> MPBuilder<MC, E, W, B> {
+		MPBuilder {
+			state:             PhantomData,
+			shared:            self.shared,
+			producer_barrier:  self.producer_barrier,
+			dependent_barrier: self.dependent_barrier,
+		}
+	}
+
 	/// Get an EventPoller.
 	pub fn new_event_poller(mut self) -> (EventPoller<E, B>, MPBuilder<SC, E, W, B>) {
 		let event_poller = self.build_event_poller();

--- a/src/builder/single.rs
+++ b/src/builder/single.rs
@@ -70,6 +70,16 @@ where
 		}
 	}
 
+	/// Force builder transition to multi consumer state. This is useful if you want to add multiple consumers in a loop.
+	pub fn with_multi_consumer(self) -> SPBuilder<MC, E, W, B> {
+		SPBuilder {
+			state:             PhantomData,
+			shared:            self.shared,
+			producer_barrier:  self.producer_barrier,
+			dependent_barrier: self.dependent_barrier,
+		}
+	}
+
 	/// Get an EventPoller.
 	pub fn new_event_poller(mut self) -> (EventPoller<E, B>, SPBuilder<SC, E, W, B>) {
 		let event_poller = self.build_event_poller();

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -49,6 +49,7 @@ impl Barrier for SingleConsumerBarrier {
 
 impl MultiConsumerBarrier {
 	pub(crate) fn new(cursors: Vec<Arc<Cursor>>) -> Self {
+		assert!(!cursors.is_empty(), "MultiConsumerBarrier must have at least one cursor");
 		Self {
 			cursors
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,8 +333,8 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic(expected = "Size must be power of 2.")]
-	fn size_not_a_factor_of_2() {
+	#[should_panic(expected = "Size must be a power of 2")]
+	fn size_is_power_of_2() {
 		build_single_producer(3, || { 0 }, BusySpin);
 	}
 
@@ -367,6 +367,12 @@ mod tests {
 		drop(producer);
 		let result: Vec<_> = r.iter().collect();
 		assert_eq!(result, [0, 1, 2, 3, 4]);
+	}
+
+	#[test]
+	#[should_panic(expected = "MultiProducerBarrier must have a size of minimum 64 slots")]
+	fn mpsc_size_is_greater_than_64() {
+		build_multi_producer(32, || { 0 }, BusySpin);
 	}
 
 	#[test]
@@ -985,6 +991,15 @@ mod tests {
 		assert_eq!(ep1.poll().err(), Some(Polling::Shutdown));
 		assert_eq!(ep2.poll().err(), Some(Polling::Shutdown));
 		assert_eq!(ep3.poll().err(), Some(Polling::Shutdown));
+	}
+
+	#[test]
+	#[should_panic(expected = "MultiConsumerBarrier must have at least one cursor")]
+	fn mpmc_without_consumers() {
+		let builder       = build_multi_producer(64, factory(), BusySpin).with_multi_consumer();
+		
+		// Must panic since no consumers have been added to the builder
+		builder.build();
 	}
 
 	#[test]

--- a/src/producer/multi.rs
+++ b/src/producer/multi.rs
@@ -244,7 +244,7 @@ pub struct MultiProducerBarrier {
 
 impl MultiProducerBarrier {
 	pub(crate) fn new(size: usize) -> Self {
-		assert!(size >= 64, "Multi Producer Disruptor must have a size of minimum 64 slots.");
+		assert!(size >= 64, "MultiProducerBarrier must have a size of minimum 64 slots");
 
 		let cursor      = Cursor::new();
 		let i64_needed  = size/64;

--- a/src/ringbuffer.rs
+++ b/src/ringbuffer.rs
@@ -16,7 +16,7 @@ impl <E> RingBuffer<E> {
 	where
 		F: FnMut() -> E
 	{
-		if !size.is_power_of_two() { panic!("Size must be power of 2.") }
+		assert!(size.is_power_of_two(), "Size must be a power of 2");
 
 		let slots: Box<[UnsafeCell<E>]> = (0..size)
 			.map(|_i| UnsafeCell::new(event_factory()) )


### PR DESCRIPTION
In reference to https://github.com/nicholassm/disruptor-rs/issues/39 this is a naive attempt at enabling runtime configuration.

This is just for demonstration purposes, I think there might be a better solution to this. At the very least I should handle the count = 0 case and return an error instead of panicing. Also, in the case of count = 1 the SC state would be the appropriate choice for consistency.

Maybe there is a cleaner solution that reduces the NC/SC/MP builder states and allow for easier runtime construction? Without fully understanding the use of the states, at least I see it is used to avoid runtime errors when consumers=0.

If that is the primary use of the states, it might be worthwhile to do runtime error checking instead and return Result<>. This would simplify the code and the builder is not in the critical path anyway.